### PR TITLE
Change 'multiplex' multistream id to 'mplex'

### DIFF
--- a/7-properties.md
+++ b/7-properties.md
@@ -202,7 +202,7 @@ TLS | /tls/1.3.0
 plaintext | /plaintext/1.0.0 
 spdy | /spdy/3.1.0
 yamux | /yamux/1.0.0
-multiplex | /multiplex/6.7.0
+multiplex | /mplex/6.7.0
 identify | /ipfs/id/1.0.0
 ping | /ipfs/ping/1.0.0
 relay | /ipfs/relay/line/1.0.0


### PR DESCRIPTION
Its less confusing, there are other multiplexers with different names, shortening it to mplex both distinguishes itself as its own protocol, and saves bytes.

Plus, this is already in go-ipfs as /mplex