### PR TITLE
Make heading levels match

### DIFF
--- a/3-requirements.md
+++ b/3-requirements.md
@@ -95,7 +95,7 @@ Connection relaying SHOULD be implemented as a transport, in order to be transpa
 For an instantiation of relaying, see the [/ipfs/relay/circuit transport](transports/circuit-relay.md).
 
 
-# 3.6 Enable several network topologies
+## 3.6 Enable several network topologies
 
 Different systems have different requirements and with that comes different topologies. In the P2P literature we can find these topologies being enumerated as: unstructured, structured, hybrid and centralized.
 


### PR DESCRIPTION
This heading was at a higher level than the others, making the later headings look like subheadings.