### PR TITLE
The Circuit Relay Specification: The first iteration

### DIFF
--- a/relay/README.md
+++ b/relay/README.md
@@ -68,47 +68,66 @@ Scene 2:
 
 ## Addressing
 
-`/p2p-circuit` multiaddrs don't carry any meaning of their own.
-They need to encapsulate a `/p2p` address, or
-be encapsulated in a `/p2p` address, or both.
+`/p2p-circuit` multiaddrs don't carry any meaning of their own. They need to encapsulate a `/p2p` address, or be encapsulated in a `/p2p` address, or both.
 
-As with all other multiaddrs, encapsulation of different protocols
-determines which metaphorical tubes to connect to each other.
+As with all other multiaddrs, encapsulation of different protocols determines which metaphorical tubes to connect to each other.
+
+A `/p2p-circuit` circuit address, is formated following:
+
+`/p2p-circuit[<relay peer multiaddr>]<destination peer multiaddr>`
+
+This opens the room for multiple hop relay, where the first relay is encapsulated in the seconf relay multiaddr, such as:
+
+`/p2p-circuit/p2p-circuit/<first relay>/<first hop multiaddr>/<destination peer multiaddr>`
 
 A few examples:
 
+Using any relay available:
+
 - `/p2p-circuit/p2p/QmTwo`
-  - Dial QmTwo, through any available relay node.
-  - The relay node will use peer routing to find an address for QmTwo.
-- `/p2p/QmRelay/p2p-circuit/p2p/QmTwo`
-  - Dial QmTwo, through QmRelay.
-  - Use peer routing to find an address for QmRelay.
-  - The relay node will also use peer routing, to find an address for QmTwo.
+  - Dial QmTwo, through any available relay node (or find one node that can relay).
+  - The relay node will use peer routing to find an address for QmTwo if it doesn't have a direct connection.
 - `/p2p-circuit/ip4/../tcp/../p2p/QmTwo`
   - Dial QmTwo, through any available relay node,
     but force the relay node to use the encapsulated `/ip4` multiaddr for connecting to QmTwo.
   - We'll probably not support forced addresses for now, just because it's complicated.
+
+Specify a relay:
+
+- `/p2p-circuit/p2p/QmRelay/p2p/QmTwo`
+  - Dial QmTwo, through QmRelay.
+  - Use peer routing to find an address for QmRelay.
+  - The relay node will also use peer routing, to find an address for QmTwo.
+- `/p2p-circuit/ip4/../tcp/../p2p/QmRelay/p2p/QmTwo`
+  - Dial QmTwo, through QmRelay.
+  - Includes info for connecting to QmRelay.
+  - The relay node will use peer routing to find an address for QmTwo.
+
+Double relay:
+
+- `/p2p-circuit/p2p/QmTwo/p2p-circuit/p2p/QmThree`
+  - Dial QmThree, through a relayed connection to QmTwo.
+  - The relay nodes will use peer routing to find an address for QmTwo and QmThree.
+  - We'll probably not support nested relayed connections for now, there are edge cases to think of.
+
+--
+
+?? I don't understand the usage of the following:
+
 - `/ip4/../tcp/../p2p/QmRelay/p2p-circuit`
   - Listen for connections relayed through QmRelay.
   - Includes info for connecting to QmRelay.
   - Also makes QmRelay available for relayed dialing, based on how listeners currently relate to dialers.
 - `/p2p/QmRelay/p2p-circuit`
   - Same as previous example, but use peer routing to find an address for QmRelay.
-- `/p2p-circuit/p2p/QmTwo/p2p-circuit/p2p/QmThree`
-  - Dial QmThree, through a relayed connection to QmTwo.
-  - The relay nodes will use peer routing to find an address for QmTwo and QmThree.
-  - We'll probably not support nested relayed connections for now, there are edge cases to think of.
-- `/ip4/../tcp/../p2p/QmRelay/p2p-circuit/p2p/QmTwo`
-  - Dial QmTwo, through QmRelay.
-  - Includes info for connecting to QmRelay.
-  - The relay node will use peer routing to find an address for QmTwo.
+
+?? I believe we don't need this one:
 - `/p2p-circuit`
   - Use relay discovery to find a suitable relay node. (Neither specified nor implemented.)
   - Listen for relayed connections.
   - Dial through the discovered relay node for any `/p2p-circuit` multiaddr.
 
-TODO: figure out forced addresses.
-TODO: figure out nested relayed connections.
+TODO: figure out forced addresses. -> what is forced addresses?
 
 ## Wire format
 

--- a/relay/README.md
+++ b/relay/README.md
@@ -26,18 +26,24 @@ libp2p already has modules for NAT ([go-libp2p-nat](https://github.com/libp2p/go
 but these don't always do the job, just because NAT traversal is complicated.
 That's why it's useful to have a simple relay protocol.
 
-One node asks a relay node to connect to another node on its behalf.
-The relay node shortcircuits its streams to the two nodes,
+Unlike a transparent **tunnel**, where a libp2p peer would just proxy a
+communication stream to a destination (the destination being unaware of the
+original source), a circuit-relay makes the destination aware of the original
+source and the circuit followed to establish communication between the two.
+This provides the destination side with full knowledge of the circuit which,
+if needed, could be rebuilt in the opposite direction.
+
+Apart from that, this relayed connection behaves just like a regular
+connection would, but over an existing swarm stream with another peer
+(instead of e.g. TCP.): One node asks a relay node to connect to another node
+on its behalf. The relay node shortcircuits its streams to the two nodes,
 and they are then connected through the relay.
-This relayed connection behaves just like a regular connection would,
-because it is in fact just that,
-but over an existing swarm stream with another peer, instead of e.g. TCP.
 
 Relayed connections are end-to-end encrypted just like regular connections.
 
 The circuit relay is both a tunneled transport and a mounted swarm protocol.
-The transport is the means of *establishing* and *accepting* connections,
-and the swarm protocol is the means to *relaying* connections.
+The transport is the means of ***establishing*** and ***accepting*** connections,
+and the swarm protocol is the means to ***relaying*** connections.
 
 ```
 +-------+    /ip4/.../tcp/.../ws/p2p/QmRelay     +---------+     /ip4/.../tcp/.../p2p/QmTwo        +-------+

--- a/relay/README.md
+++ b/relay/README.md
@@ -240,6 +240,7 @@ This is a table of error codes and sample messages that may occur during a relay
 | 261   | "active relay could not connect to dst: connection refused" | relay could not form new connection to target peer |
 | 262   | "could not open new stream to dst: BAD ERROR" | relay has connection to dst, but failed to open a new stream |
 | 270   | "<dst> does not support relay" | |
+| 280   | "can't relay to itself" | The relay got its own address as destination|
 | 320   | "src address too long" | |
 | 321   | "dst address too long" | |
 | 350   | "failed to parse src addr: no such protocol ifps" | The `<src>` multiaddr in the header was invalid |

--- a/relay/README.md
+++ b/relay/README.md
@@ -20,7 +20,7 @@
 
 The circuit relay is a means of establishing connectivity between libp2p nodes (such as IPFS) that wouldn't otherwise be able to establish a direct connection to each other.
 
-This helps in situations where nodes are behind NAT or reverse proxies, or simply don't support the same transports (e.g. go-ipfs vs. browser-ipfs). libp2p already has modules for NAT ([go-libp2p-nat](https://github.com/libp2p/go-libp2p-nat)), however piercing through NATs is not always a option due to their implementation differences. The circuit relay protocol exist to overcome those scenarios.
+This helps in situations where nodes are behind NAT or reverse proxies, or simply don't support the same transports (e.g. go-ipfs vs. browser-ipfs). libp2p already has modules for NAT ([go-libp2p-nat](https://github.com/libp2p/go-libp2p-nat)), however piercing through NATs is not always an option due to their implementation differences. The circuit relay protocol exists to overcome those scenarios.
 
 Unlike a transparent **tunnel**, where a libp2p peer would just proxy a communication stream to a destination (the destination being unaware of the original source), a circuit-relay makes the destination aware of the original source and the circuit followed to establish communication between the two. This provides the destination side with full knowledge of the circuit which, if needed, could be rebuilt in the opposite direction.
 
@@ -77,10 +77,10 @@ A `/p2p-circuit` circuit address, is formated following:
 
 Examples:
 
-- `/p2p-circuit/p2p/QmVT6GYwjeeAF5TR485Yc58S3xRF5EFsZ5YAF4VcP3URHt` - No known relay
-- `/ip4/127.0.0.1/tcp/5002/ipfs/QmdPU7PfRyKehdrP5A3WqmjyD6bhVpU1mLGKppa2FjGDjZ/p2p-circuit/p2p/QmVT6GYwjeeAF5TR485Yc58S3xRF5EFsZ5YAF4VcP3URHt` - Known relay
+- `/p2p-circuit/p2p/QmVT6GYwjeeAF5TR485Yc58S3xRF5EFsZ5YAF4VcP3URHt` - Arbitrary relay node
+- `/ip4/127.0.0.1/tcp/5002/ipfs/QmdPU7PfRyKehdrP5A3WqmjyD6bhVpU1mLGKppa2FjGDjZ/p2p-circuit/p2p/QmVT6GYwjeeAF5TR485Yc58S3xRF5EFsZ5YAF4VcP3URHt` - Specific relay node
 
-This opens the room for multiple hop relay, where the first relay is encapsulated in the second relay multiaddr, such as:
+This opens the room for multiple hop relay, where the second relay is encapsulated in the first relay multiaddr, such as:
 
 `<1st relay>/p2p-circuit/<2nd relay>/p2p-circuit/<dst multiaddr>`
 


### PR DESCRIPTION
In an attempt to converge all the relay spec notes and discussions, I'm listing them here, so that they can all be considered for the revamp of the relay spec. (Order represents the timeline of how theses appear, last should be considered as last 'discussed')

- first iteration of the spec - https://github.com/libp2p/specs/blob/master/relay/README.md
- question: wire protocol message format - https://github.com/libp2p/specs/issues/12
- question: relay vs tunnel - https://github.com/libp2p/specs/pull/8
- implementation notes - https://github.com/libp2p/js-libp2p-circuit/blob/master/implementation-notes.md
- Why's concerns about current implementation - https://github.com/libp2p/js-libp2p-circuit/issues/8
- Relay use cases - https://github.com/libp2p/js-libp2p-circuit/issues/6
- moar notes - https://github.com/libp2p/js-libp2p-circuit/issues/2
- moar discussion - https://github.com/libp2p/js-libp2p-circuit/issues/4
- errors table: https://gist.github.com/whyrusleeping/7665164d04e43171e6cb7b8aa6205645#file-errors-md
- wire protocol: https://gist.github.com/whyrusleeping/7665164d04e43171e6cb7b8aa6205645#file-relay-md
