### PR TITLE
RFC: rendezvous

### DIFF
--- a/rendezvous/README.md
+++ b/rendezvous/README.md
@@ -157,6 +157,7 @@ message Message {
     E_INVALID_COOKIE    = 103;
     E_NOT_AUTHORIZED    = 200;
     E_INTERNAL_ERROR    = 300;
+    E_UNAVAILABLE       = 400;
   }
 
   message PeerInfo {

--- a/rendezvous/README.md
+++ b/rendezvous/README.md
@@ -144,6 +144,16 @@ R -> D: {[REGISTER{my-app, {QmE, AddrE}}],
          c3}
 ```
 
+### Proof of Work
+
+The protocol as described so far is susceptible to spam attacks from
+adversarial actors who generate a large number of peer identities and
+register under a namespace of interest (eg: the relay namespace). This
+can be mitigated by requiring a Proof of Work scheme for client
+registrations.
+
+This is TBD before finalizing the spec.
+
 ### Protobuf
 
 ```protobuf

--- a/rendezvous/README.md
+++ b/rendezvous/README.md
@@ -1,5 +1,9 @@
 # Rendezvous Protocol
 
+Author: vyzo
+
+Revision: DRAFT; 2019-01-18
+
 The protocol described in this specification is intended to provide a
 lightweight mechanism for generalized peer discovery. It can be used
 for bootstrap purposes, real time peer discovery, application specific

--- a/rendezvous/README.md
+++ b/rendezvous/README.md
@@ -73,9 +73,11 @@ managed.
 
 Registration lifetime is controlled by an optional TTL parameter in
 the `REGISTER` message.  If a TTL is specified, then the registration
-persists until the TTL expires.  If no TTL was specified, then the
-registration persists while the issuing peer is still connected to the
-rendezvous point.
+persists until the TTL expires.  If no TTL was specified, then a default
+of 2hrs is implied. There may be a rendezvous point-specific upper bound
+on TTL, with a minimum such value of 72hrs. If the TTL of a registration
+is inadmissible, the rendezvous point may reject the registration with
+an `E_INVALID_TTL` status.
 
 Peers can refresh their registrations at any time with a new
 `REGISTER` message; the TTL of the new message supersedes previous
@@ -160,6 +162,7 @@ message Message {
     OK = 0;
     E_INVALID_NAMESPACE = 100;
     E_INVALID_PEER_INFO = 101;
+    E_INVALID_TTL       = 102;
     E_NOT_AUTHORIZED    = 200;
   }
 

--- a/rendezvous/README.md
+++ b/rendezvous/README.md
@@ -162,7 +162,7 @@ message Message {
     E_NOT_AUTHORIZED    = 200;
   }
 
-  message RegisterReponse {
+  message RegisterResponse {
     optional RegisterStatus code = 1;
   }
 
@@ -173,7 +173,7 @@ message Message {
 
   message Discover {
     optional string ns = 1;
-    optional int limit = 2;
+    optional int64 limit = 2;
     optional int64 since = 3;
   }
 

--- a/rendezvous/README.md
+++ b/rendezvous/README.md
@@ -190,3 +190,4 @@ message Message {
   optional Discover discover = 5;
   optional DiscoverResponse discoverResponse = 6;
 }
+```

--- a/rendezvous/README.md
+++ b/rendezvous/README.md
@@ -86,6 +86,9 @@ Peers can refresh their registrations at any time with a new
 registrations. Peers can also cancel existing registrations at any
 time with an explicit `UNREGISTER` message.
 
+The registration response includes the actual TTL of the registration,
+so that peers know when to refresh.
+
 ### Interaction
 
 Clients `A` and `B` connect to the rendezvous point `R` and register for namespace
@@ -174,6 +177,7 @@ message Message {
   message RegisterResponse {
     optional ResponseStatus status = 1;
     optional string statusText = 2;
+    optional int64 ttl = 3; // in seconds
   }
 
   message Unregister {

--- a/rendezvous/README.md
+++ b/rendezvous/README.md
@@ -1,0 +1,86 @@
+# Rendezvous Service
+
+Scope:
+- real-time applications that require rendezvous; replace ws-star-rendezvous
+  in conjunction with p2p-circuit relays.
+
+## Rendezvous Protocol
+
+The rendezvous protocol provides facilities for real-time peer discovery within
+application specific namespaces. Peers connect to the rendezvous service and register
+their presence in one or more namespaces; they can subsequently enter rendezvous
+and receive announcements about peer registrations and unregistrations within their
+namespaces of interest. Registrations persist until the peer disconnects or explicitly
+unregisters.
+
+### Interaction
+
+Client peer `A` connects to the rendezvous service `R` and registers for namespace
+`my-app` with a `REGISTER` message. It subsequently enters rendezvous with
+a `RENDEZVOUS` message and waits for `REGISTER`/`UNREGISTER` announcements from
+the service.
+
+```
+A -> R: REGISTER{my-app, {QmA, AddressA}}
+A -> R: RENDEZVOUS{my-app}
+```
+
+Client peer `B` connects, registers and enters rendezvous.
+The rendezvous service immediately notifies `B` about the current namespace registrations
+and emits a register notification to `A`:
+
+```
+B -> R: REGISTER{my-app, {QmB, AddressB}}
+B -> R: RENDEZVOUS{my-app}
+
+R -> B: REGISTER{my-app, {QmA, AddressA}}
+R -> A: REGISTER{my-app, {QmB, AddressB}}
+```
+
+A third client `C` connections and registers:
+```
+C -> R: REGISTER{my-app, {QmC, AddressC}}
+C -> R: RENDEZVOUS{my-app}
+
+R -> C: REGISTER{my-app, {QmA, AddressA}}
+R -> C: REGISTER{my-app, {QmB, AddressB}}
+R -> A: REGISTER{my-app, {QmC, AddressC}}
+R -> B: REGISTER{my-app, {QmC, AddressC}}
+```
+
+### Protobuf
+
+
+```protobuf
+message Message {
+  enum MessageType {
+    REGISTER = 0;
+    UNREGISTER = 1;
+    RENDEZVOUS = 2;
+  }
+
+  message Peer {
+    optional string id = 1;
+    repeated bytes addrs = 2;
+  }
+
+  message Register {
+    optional string ns = 1;
+    optional Peer peer = 2;
+  }
+
+  message Unregister {
+    optional string ns = 1;
+    optional Peer peer = 2;
+  }
+
+  message Rendezvous {
+    optional string ns = 1;
+  }
+
+  optional MessageType type = 1;
+  repeated Register register = 2;
+  repeated Unregister unregister = 3;
+  repeated Rendezvous rendezvous = 4;
+}
+```

--- a/rendezvous/README.md
+++ b/rendezvous/README.md
@@ -147,6 +147,16 @@ message Message {
     DISCOVER_RESPONSE = 4;
   }
 
+  enum ResponseStatus {
+    OK                  = 0;
+    E_INVALID_NAMESPACE = 100;
+    E_INVALID_PEER_INFO = 101;
+    E_INVALID_TTL       = 102;
+    E_INVALID_COOKIE    = 103;
+    E_NOT_AUTHORIZED    = 200;
+    E_INTERNAL_ERROR    = 300;
+  }
+
   message PeerInfo {
     optional bytes id = 1;
     repeated bytes addrs = 2;
@@ -156,16 +166,6 @@ message Message {
     optional string ns = 1;
     optional PeerInfo peer = 2;
     optional int64 ttl = 3; // in seconds
-  }
-
-  enum ResponseStatus {
-    OK                  = 0;
-    E_INVALID_NAMESPACE = 100;
-    E_INVALID_PEER_INFO = 101;
-    E_INVALID_TTL       = 102;
-    E_INVALID_COOKIE    = 103;
-    E_NOT_AUTHORIZED    = 200;
-    E_INTERNAL_ERROR    = 300;
   }
 
   message RegisterResponse {

--- a/rendezvous/README.md
+++ b/rendezvous/README.md
@@ -93,7 +93,7 @@ message Message {
   }
 
   message Discover {
-    optional string namespace = 1;
+    optional string ns = 1;
   }
 
   optional MessageType type = 1;

--- a/rendezvous/README.md
+++ b/rendezvous/README.md
@@ -41,7 +41,7 @@ horizontally scalable ensemble of daemons.
 Rendezvous can be naturally combined with pubsub for effective
 real-time discovery.  At a basic level, rendezvous can be used to
 bootstrap pubsub: nodes can utilize rendezvous in order to discover
-their peers within a topic.  Contrariwise, pubsub can also be used as
+their peers within a topic.  Alternatively, pubsub can also be used as
 a mechanism for building rendezvous services. In this scenerio, a
 number of rendezvous points can federate using pubsub for internal
 real-time distribution, while still providing a simple interface to

--- a/rendezvous/README.md
+++ b/rendezvous/README.md
@@ -1,8 +1,8 @@
 # Rendezvous Service
 
 Scope:
-- real-time applications that require rendezvous; replace ws-star-rendezvous
-  in conjunction with p2p-circuit relays.
+- real-time applications that require rendezvous
+- replace ws-star-rendezvous in conjunction with p2p-circuit relays.
 
 ## Rendezvous Protocol
 

--- a/rendezvous/README.md
+++ b/rendezvous/README.md
@@ -14,8 +14,8 @@ disconnects or explicitly unregisters.
 
 Peers can enter rendezvous and dynamically receive announcements about peer
 registrations and unregistrations within their namespaces of interest.
-For purposes of discovery (eg bootstrap), peers can also ask the service for
-a oneof list of peers within a namespace.
+For purposes of oneof discovery (eg bootstrap), peers can also ask the service
+for a list of peers within a namespace.
 
 ### Interaction
 
@@ -94,6 +94,7 @@ message Message {
 
   message Discover {
     optional string ns = 1;
+    optional int limit = 2;
   }
 
   optional MessageType type = 1;

--- a/rendezvous/README.md
+++ b/rendezvous/README.md
@@ -53,14 +53,26 @@ clients.
 The rendezvous protocol provides facilities for real-time peer
 discovery within application specific namespaces. Peers connect to the
 rendezvous point and register their presence in one or more
-namespaces. Registrations persist until the peer disconnects or
-explicitly unregisters.
+namespaces.
 
 Peers registered with the rendezvous point can be discovered by other
 nodes by querying the rendezvous point. The query specifies the
 namespace for limiting application scope and optionally a maximum
 number of peers to return. The namespace can be omitted in the query,
 which asks for all peers registered to the rendezvous point.
+
+### Registration Lifetime
+
+Registration lifetime is controlled by an optional TTL parameter in
+the `REGISTER` message.  If a TTL is specified, then the registration
+persists until the TTL expires.  If no TTL was specified, then the
+registration persists while the issuing peer is still connected to the
+rendezvous point.
+
+Peers can refresh their registrations at any time with a new
+`REGISTER` message; the TTL of the new message supersedes previous
+registrations. Peers can also cancel existing registrations at any
+time with an explicit `UNREGISTER` message.
 
 ### Interaction
 
@@ -113,6 +125,7 @@ message Message {
   message Register {
     optional string ns = 1;
     optional PeerInfo peer = 2;
+    optional uint ttl = 3;
   }
 
   message Unregister {

--- a/rendezvous/README.md
+++ b/rendezvous/README.md
@@ -129,8 +129,8 @@ message Message {
   }
 
   optional MessageType type = 1;
-  repeated Register register = 2;
-  repeated Unregister unregister = 3;
-  repeated Discover discover = 4;
-  repeated DiscoverResponse discoverResponse = 5;
+  optional Register register = 2;
+  optional Unregister unregister = 3;
+  optional Discover discover = 4;
+  optional DiscoverResponse discoverResponse = 5;
 }

--- a/rendezvous/README.md
+++ b/rendezvous/README.md
@@ -164,7 +164,7 @@ message Message {
   }
 
   message RegisterResponse {
-    optional RegisterStatus code = 1;
+    optional RegisterStatus status = 1;
   }
 
   message Unregister {

--- a/rendezvous/README.md
+++ b/rendezvous/README.md
@@ -53,7 +53,9 @@ clients.
 The rendezvous protocol provides facilities for real-time peer
 discovery within application specific namespaces. Peers connect to the
 rendezvous point and register their presence in one or more
-namespaces.
+namespaces. It is not allowed to register arbitrary peers in a
+namespace; only the peer initiating the registration can register
+itself.
 
 Peers registered with the rendezvous point can be discovered by other
 nodes by querying the rendezvous point. The query specifies the

--- a/rendezvous/README.md
+++ b/rendezvous/README.md
@@ -158,16 +158,19 @@ message Message {
     optional int64 ttl = 3; // in seconds
   }
 
-  enum RegisterStatus {
-    OK = 0;
+  enum ResponseStatus {
+    OK                  = 0;
     E_INVALID_NAMESPACE = 100;
     E_INVALID_PEER_INFO = 101;
     E_INVALID_TTL       = 102;
+    E_INVALID_COOKIE    = 103;
     E_NOT_AUTHORIZED    = 200;
+    E_INTERNAL_ERROR    = 300;
   }
 
   message RegisterResponse {
-    optional RegisterStatus status = 1;
+    optional ResponseStatus status = 1;
+    optional string statusText = 2;
   }
 
   message Unregister {
@@ -184,6 +187,8 @@ message Message {
   message DiscoverResponse {
     repeated Register registrations = 1;
     optional bytes cookie = 2;
+    optional ResponseStatus status = 3;
+    optional string statusText = 4;
   }
 
   optional MessageType type = 1;


### PR DESCRIPTION
Only thing I can see missing is adding the `E_UNAVAILABLE` which will be used when registrations are happening too fast or it's generally overloaded with the already registered clients.

Previous: https://github.com/libp2p/specs/pull/44 (mostly doesn't load)