### PR TITLE
RFC: Add relay backoff code

### DIFF
--- a/relay/README.md
+++ b/relay/README.md
@@ -133,6 +133,7 @@ message CircuitRelay {
     HOP_CANT_OPEN_DST_STREAM   = 262;
     HOP_CANT_SPEAK_RELAY       = 270;
     HOP_CANT_RELAY_TO_SELF     = 280;
+    HOP_BACKOFF                = 290;
     STOP_SRC_ADDR_TOO_LONG     = 320;
     STOP_DST_ADDR_TOO_LONG     = 321;
     STOP_SRC_MULTIADDR_INVALID = 350;
@@ -209,6 +210,7 @@ This is a table of status codes and sample messages that may occur during a rela
 | 262   | "couldn't' dial to dst"                           | relay has conn to dst, but failed to open a stream |
 | 270   | "dst does not support relay"                      | |
 | 280   | "can't relay to itself"                           | The relay got its own address as destination |
+| 290   | "temporary backoff"                               | The relay wants us to backoff and try again later |
 | 320   | "src address too long"                            | |
 | 321   | "dst address too long"                            | |
 | 350   | "failed to parse src addr"                        | src multiaddr in the header was invalid |


### PR DESCRIPTION
I think it would be very useful for relays to have a way to signal to their clients that they are overloaded or want to temporarily stop relaying new connections. I think that a simple response code like this is sufficient at the protocol level to allow various load management strategies to be implemented.