### PR TITLE
Rfc/gossipsub

### DIFF
--- a/2-state-of-the-art.md
+++ b/2-state-of-the-art.md
@@ -1,7 +1,25 @@
+
 2 An analysis of the state of the art in network stacks
 ====================================================
 
 This section presents to the reader an analysis of the available protocols and architectures for network stacks. The goal is to provide the foundations from which to infer the conclusions and understand why `libp2p` has the requirements and architecture that it has.
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Contents**
+
+- [2 An analysis of the state of the art in network stacks](#2-an-analysis-of-the-state-of-the-art-in-network-stacks)
+  - [2.1 The client-server model](#21-the-client-server-model)
+  - [2.2 Categorizing the network stack protocols by solutions](#22-categorizing-the-network-stack-protocols-by-solutions)
+    - [2.2.1 Establishing the physical link](#221-establishing-the-physical-link)
+    - [2.2.2 Addressing a machine or process](#222-addressing-a-machine-or-process)
+    - [2.2.3 Discovering other peers or services](#223-discovering-other-peers-or-services)
+    - [2.2.4 Routing messages through the network](#224-routing-messages-through-the-network)
+    - [2.2.5 Transport](#225-transport)
+    - [2.2.6 Agreed semantics for applications to talk to each other](#226-agreed-semantics-for-applications-to-talk-to-each-other)
+  - [2.3 Current shortcomings](#23-current-shortcomings)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## 2.1 The client-server model
 

--- a/3-requirements.md
+++ b/3-requirements.md
@@ -1,6 +1,23 @@
 3 Requirements and considerations
 =================================
 
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Contents**
+
+- [3 Requirements and considerations](#3-requirements-and-considerations)
+  - [3.1 Transport agnostic](#31-transport-agnostic)
+  - [3.2 Multi-multiplexing](#32-multi-multiplexing)
+  - [3.3 Encryption](#33-encryption)
+  - [3.4 NAT traversal](#34-nat-traversal)
+  - [3.5 Relay](#35-relay)
+  - [3.6 Enable several network topologies](#36-enable-several-network-topologies)
+  - [3.7 Resource discovery](#37-resource-discovery)
+  - [3.8 Messaging](#38-messaging)
+  - [3.9 Naming](#39-naming)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 ## 3.1 Transport agnostic
 
 `libp2p` is transport agnostic, so it can run over any transport protocol. It does not even depend on IP; it may run on top of NDN, XIA, and other new Internet architectures.

--- a/4-architecture.md
+++ b/4-architecture.md
@@ -23,6 +23,39 @@ Each of these subsystems exposes a well known interface (see [chapter 6](6-inter
 └─────────────────┘└─────────────────┘└──────────────────────────┘└───────────────┘
 ```
 
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Contents**
+
+- [4 Architecture](#4-architecture)
+  - [4.1 Peer Routing](#41-peer-routing)
+    - [4.1.1 kad-routing](#411-kad-routing)
+    - [4.1.2 mDNS-routing](#412-mdns-routing)
+  - [4.2 Swarm](#42-swarm)
+    - [4.2.1 Stream Muxer](#421-stream-muxer)
+    - [4.2.2 Protocol Muxer](#422-protocol-muxer)
+    - [4.2.3 Transport](#423-transport)
+    - [4.2.4 Crypto](#424-crypto)
+    - [4.2.5 Identify](#425-identify)
+    - [4.2.6 Relay](#426-relay)
+  - [4.3 Distributed Record Store](#43-distributed-record-store)
+    - [4.3.1 Record](#431-record)
+    - [4.3.2 abstract-record-store](#432-abstract-record-store)
+    - [4.3.3 kad-record-store](#433-kad-record-store)
+    - [4.3.4 mDNS-record-store](#434-mdns-record-store)
+    - [4.3.5 s3-record-store](#435-s3-record-store)
+  - [4.4 Discovery](#44-discovery)
+    - [4.4.1 mDNS-discovery](#441-mdns-discovery)
+      - [4.4.2 random-walk](#442-random-walk)
+      - [4.4.3 bootstrap-list](#443-bootstrap-list)
+  - [4.5 Messaging](#45-messaging)
+      - [4.5.1 PubSub](#451-pubsub)
+  - [4.6 Naming](#46-naming)
+      - [4.6.1 IPRS](#461-iprs)
+      - [4.6.2 IPNS](#462-ipns)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 ## 4.1 Peer Routing
 
 A Peer Routing subsystem exposes an interface to identify which peers a message should be routed to in the DHT. It receives a key and must return one or more `PeerInfo` objects.

--- a/6-interfaces.md
+++ b/6-interfaces.md
@@ -3,6 +3,27 @@
 
 `libp2p` is a collection of several protocols working together to offer a common solid interface that can talk with any other network addressable process. This is made possible by shimming currently existing protocols and implementations into a set of explicit interfaces: Peer Routing, Discovery, Stream Muxing, Transports, Connections and so on.
 
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Contents**
+
+- [6 Interfaces](#6-interfaces)
+  - [6.1 libp2p](#61-libp2p)
+  - [6.2 Peer Routing](#62-peer-routing)
+  - [6.3 Swarm](#63-swarm)
+    - [6.3.1 Transport](#631-transport)
+    - [6.3.2 Connection](#632-connection)
+    - [6.3.3 Stream Muxing](#633-stream-muxing)
+  - [6.4 Distributed Record Store](#64-distributed-record-store)
+  - [6.5 Peer Discovery](#65-peer-discovery)
+  - [6.6 libp2p interface and UX](#66-libp2p-interface-and-ux)
+    - [Constructing a libp2p instance programatically](#constructing-a-libp2p-instance-programatically)
+    - [Dialing and Listening for connections to/from a peer](#dialing-and-listening-for-connections-tofrom-a-peer)
+    - [Finding a peer](#finding-a-peer)
+    - [Storing and Retrieving Records](#storing-and-retrieving-records)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 ## 6.1 libp2p
 
 `libp2p`, the top module that provides an interface to all the other modules that make a `libp2p` instance, must offer an interface for dialing to a peer and plugging in all of the modules (e.g. which transports) we want to support. We present the `libp2p` interface and UX in [section 6.6](#66-libp2p-interface-and-ux), after presenting every other module interface.

--- a/7-properties.md
+++ b/7-properties.md
@@ -1,6 +1,27 @@
 7 Properties
 ============
 
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Contents**
+
+- [7 Properties](#7-properties)
+  - [7.1 Communication Model - Streams](#71-communication-model---streams)
+  - [7.2 Ports - Constrained Entrypoints](#72-ports---constrained-entrypoints)
+  - [7.3 Transport Protocols](#73-transport-protocols)
+  - [7.4 Non-IP Networks](#74-non-ip-networks)
+  - [7.5 On the wire](#75-on-the-wire)
+    - [7.5.1 Protocol-Multiplexing](#751-protocol-multiplexing)
+    - [7.5.2 multistream - self-describing protocol stream](#752-multistream---self-describing-protocol-stream)
+    - [7.5.3 multistream-selector - self-describing protocol stream selector](#753-multistream-selector---self-describing-protocol-stream-selector)
+    - [7.5.4 Stream Multiplexing](#754-stream-multiplexing)
+    - [7.5.5 Portable Encodings](#755-portable-encodings)
+    - [7.5.6 Secure Communications](#756-secure-communications)
+    - [7.5.7 Protocol Multicodecs](#757-protocol-multicodecs)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+
 ## 7.1 Communication Model - Streams
 
 The Network layer handles all the problems of connecting to a peer, and exposes

--- a/8-implementations.md
+++ b/8-implementations.md
@@ -3,6 +3,17 @@
 
 A `libp2p` implementation should (recommended) follow a certain level of granularity when implementing different modules and functionalities, so that common interfaces are easy to expose, test and check for interoperability with other implementations.
 
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Contents**
+
+- [8 Implementations](#8-implementations)
+  - [8.1 Swarm](#81-swarm)
+    - [8.1.1 Swarm Dialer](#811-swarm-dialer)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+
 This is the list of current modules available for `libp2p`:
 
   - libp2p (entry point)

--- a/8-implementations.md
+++ b/8-implementations.md
@@ -1,3 +1,4 @@
+
 8 Implementations
 =================
 

--- a/IPRS.md
+++ b/IPRS.md
@@ -1,4 +1,28 @@
 # IPRS - InterPlanetary Record System spec
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Contents**
+
+- [IPRS - InterPlanetary Record System spec](#iprs---interplanetary-record-system-spec)
+  - [Definitions](#definitions)
+    - [Records](#records)
+    - [Record System](#record-system)
+    - [Validity Schemes](#validity-schemes)
+    - [Merkle DAG and IPFS Objects](#merkle-dag-and-ipfs-objects)
+  - [Constraints](#constraints)
+  - [Construction](#construction)
+    - [The Objects](#the-objects)
+    - [The Interface](#the-interface)
+    - [Interface Example](#interface-example)
+  - [Example Record Types](#example-record-types)
+    - [Signed, valid within a datetime range](#signed-valid-within-a-datetime-range)
+    - [Signed, expiring after a Time-To-Live](#signed-expiring-after-a-time-to-live)
+    - [Signed, based on ancestry (chain)](#signed-based-on-ancestry-chain)
+    - [Signed, with cryptographic freshness](#signed-with-cryptographic-freshness)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 Authors: [Juan Benet](github.com/jbenet)
 
 Reviewers:

--- a/pubsub/README.md
+++ b/pubsub/README.md
@@ -1,5 +1,24 @@
 # PubSub interface for libp2p
 
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Contents**
+
+- [PubSub interface for libp2p](#pubsub-interface-for-libp2p)
+  - [The RPC](#the-rpc)
+  - [The Message](#the-message)
+  - [The Topic Descriptor](#the-topic-descriptor)
+    - [AuthOpts](#authopts)
+      - [AuthMode 'NONE'](#authmode-none)
+      - [AuthMode 'KEY'](#authmode-key)
+      - [AuthMode 'WOT'](#authmode-wot)
+    - [EncOpts](#encopts)
+      - [EncMode 'NONE'](#encmode-none)
+      - [EncMode 'SHAREDKEY'](#encmode-sharedkey)
+      - [EncMode 'WOT'](#encmode-wot)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 Revision: draft 1, 2017-02-17
 
 Authors:

--- a/pubsub/gossipsub/episub.md
+++ b/pubsub/gossipsub/episub.md
@@ -13,25 +13,28 @@ Author's note:
   optimized for single source multicast and scenarios with a few fixed sources
   broadcasting to a large number of clients in a topic.
 
-<!-- toc -->
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Contents**
 
-- [Introduction](#introduction)
-- [Membership Management Protocol](#membership-management-protocol)
-  * [Design Parameters for View Sizes](#design-parameters-for-view-sizes)
-  * [Joining the Overlay](#joining-the-overlay)
-  * [Leaving the Overlay](#leaving-the-overlay)
-  * [Active View Management](#active-view-management)
-  * [Passive View Management](#passive-view-management)
-- [Broadcast Protocol](#broadcast-protocol)
-  * [Broadcast State](#broadcast-state)
-  * [Message Propagation and Multicast Tree Construction](#message-propagation-and-multicast-tree-construction)
-  * [Multicast Tree Repair](#multicast-tree-repair)
-  * [Multicast Tree Optimization](#multicast-tree-optimization)
-  * [Active View Changes](#active-view-changes)
-- [Protocol Messages](#protocol-messages)
-- [Differences from Plumtree/HyParView](#differences-from-plumtreehyparview)
+- [Episub: Proximity Aware Epidemic PubSub for libp2p](#episub-proximity-aware-epidemic-pubsub-for-libp2p)
+  - [Introduction](#introduction)
+  - [Membership Management Protocol](#membership-management-protocol)
+    - [Design Parameters for View Sizes](#design-parameters-for-view-sizes)
+    - [Joining the Overlay](#joining-the-overlay)
+    - [Leaving the Overlay](#leaving-the-overlay)
+    - [Active View Management](#active-view-management)
+    - [Passive View Management](#passive-view-management)
+  - [Broadcast Protocol](#broadcast-protocol)
+    - [Broadcast State](#broadcast-state)
+    - [Message Propagation and Multicast Tree Construction](#message-propagation-and-multicast-tree-construction)
+    - [Multicast Tree Repair](#multicast-tree-repair)
+    - [Multicast Tree Optimization](#multicast-tree-optimization)
+    - [Active View Changes](#active-view-changes)
+  - [Protocol Messages](#protocol-messages)
+  - [Differences from Plumtree/HyParView](#differences-from-plumtreehyparview)
 
-<!-- tocstop -->
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Introduction
 

--- a/relay/README.md
+++ b/relay/README.md
@@ -2,21 +2,35 @@
 
 > Circuit Switching for libp2p, also known as TURN or Relay in Networking literature.
 
+
+
 ## Implementations
 
 - [js-libp2p-circuit](https://github.com/libp2p/js-libp2p-circuit)
 - [go-libp2p-circuit](https://github.com/libp2p/go-libp2p-circuit)
 - [rust-libp2p](https://github.com/libp2p/rust-libp2p/tree/master/relay)
 
-## Table of Contents
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Contents**
 
-- [Overview](#overview)
-- [Dramatization](#dramatization)
-- [Addressing](#addressing)
-- [Wire protocol](#wire-protocol)
-- [Interfaces](#interfaces)
-- [Implementation Details](#implementation-details)
-- [Removing existing relay protocol](#removing-existing-relay-protocol)
+- [Circuit Relay v0.1.0](#circuit-relay-v010)
+  - [Implementations](#implementations)
+  - [Table of Contents](#table-of-contents)
+  - [Overview](#overview)
+  - [Dramatization](#dramatization)
+  - [Addressing](#addressing)
+  - [Wire format](#wire-format)
+    - [Relay Message](#relay-message)
+    - [High level overview of establishing a relayed connection](#high-level-overview-of-establishing-a-relayed-connection)
+    - [Under the microscope](#under-the-microscope)
+    - [Status codes table](#status-codes-table)
+  - [Implementation details](#implementation-details)
+    - [Interfaces](#interfaces)
+    - [Removing existing relay protocol in Go](#removing-existing-relay-protocol-in-go)
+  - [Future work](#future-work)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Overview
 


### PR DESCRIPTION
Has minor edits to the gossipsub README for grammar and clarity. Unfortunately, I forgot to checkout back to master before making the doctoc modifications to it and the other docs, and didn't split up the commits enough to be able to cherry-pick the changes to gossipsub and doctoc... I'll check out to a new branch, then edit the gossipsub readme to make it as it is now, and split to different PRs from there...