### PR TITLE
Add a note to say that `TopicDescriptor` isn't used

### DIFF
--- a/pubsub/README.md
+++ b/pubsub/README.md
@@ -89,10 +89,10 @@ future.
 
 ## The Topic Descriptor
 
-The topic descriptor message is not used in current implementations, but
-may be used in future to define various options and parameters
-of a topic. For clarity, it is recommended to not include the 
-`TopicDescriptor` in the `.proto` file until is is used.
+The `AuthOpts` and `EncOpts` of the topic descriptor message 
+are not used in current implementations, but
+may be used in future. For clarity, it is recommended to not include  
+them in the `.proto` file until is is used.
 It currently specifies the topic's human readable name, its
 authentication options, and its encryption options.
 

--- a/pubsub/README.md
+++ b/pubsub/README.md
@@ -91,7 +91,9 @@ future.
 
 The topic descriptor message is not used in current implementations, but
 may be used in future to define various options and parameters
-of a topic. It currently specifies the topic's human readable name, its
+of a topic. For clarity, it is recommended to not include the 
+`TopicDescriptor` in the `.proto` file until is is used.
+It currently specifies the topic's human readable name, its
 authentication options, and its encryption options.
 
 The `TopicDescriptor` protobuf is as follows:

--- a/pubsub/README.md
+++ b/pubsub/README.md
@@ -89,7 +89,8 @@ future.
 
 ## The Topic Descriptor
 
-The topic descriptor message is used to define various options and parameters
+The topic descriptor message is not used in current implementations, but
+may be used in future to define various options and parameters
 of a topic. It currently specifies the topic's human readable name, its
 authentication options, and its encryption options.
 

--- a/pubsub/README.md
+++ b/pubsub/README.md
@@ -91,8 +91,8 @@ future.
 
 The `AuthOpts` and `EncOpts` of the topic descriptor message 
 are not used in current implementations, but
-may be used in future. For clarity, it is recommended to not include  
-them in the `.proto` file until is is used.
+may be used in future. For clarity, this is added as a comment in
+the file, and may be removed once used.
 It currently specifies the topic's human readable name, its
 authentication options, and its encryption options.
 
@@ -101,6 +101,8 @@ The `TopicDescriptor` protobuf is as follows:
 ```protobuf
 message TopicDescriptor {
 	optional string name = 1;
+	// AuthOpts and EncOpts are unused as of Oct 2018, but
+	// are planned to be used in future.
 	optional AuthOpts auth = 2;
 	optional EncOpts enc = 3;
 


### PR DESCRIPTION
We need to also add a way to use a `topicID` (in a forward and backward compatible way?).

You could just use `TopicDescriptor.name`.

Edit: for future compatibility with using a CID I suggest using an enum, `TopicID`, that contains the name. Then when a topic CID is implemented that can be added to enum. That at least works well for Rust, although I'm not sure about Go and JS. I could add that to the spec.