### PR TITLE
Add peer as argument to control message functions

### DIFF
--- a/pubsub/gossipsub/README.md
+++ b/pubsub/gossipsub/README.md
@@ -265,13 +265,13 @@ it publishes the message:
   source of the message.
 
 After processing the payload, it then processes the control messages in the envelope:
-- On `GRAFT(topic)` it adds the peer to `mesh[topic]` if it is
+- On `GRAFT(topic, peer)` it adds the peer to `mesh[topic]` if it is
   subscribed to the topic. If it is not subscribed, it responds with a `PRUNE(topic)`
   control message.
-- On `PRUNE(topic)` it removes the peer from `mesh[topic]`.
-- On `IHAVE(ids)` it checks the `seen` set and requests unknown messages with an `IWANT`
+- On `PRUNE(topic, peer)` it removes the peer from `mesh[topic]`.
+- On `IHAVE(ids, peer)` it checks the `seen` set and requests unknown messages with an `IWANT`
    message.
-- On `IWANT(ids)` it forwards all request messages that are present in `mcache` to the
+- On `IWANT(ids, peer)` it forwards all request messages that are present in `mcache` to the
    requesting peer.
 
 When the router publishes a message that originates from the router itself (at the


### PR DESCRIPTION
Reasons for doing this: 
* the Go impl does this, 
* the spec supports this with statements such as "On `JOIN(topic)` the router joins the topic. In order to do so, it
  selects `D` peers from `peers.gossipsub[topic]`, adds them to `mesh[topic]`
  and notifies them with a `GRAFT(topic)` control message."

While it may be implied as a method, that is not the case when joining, since `join` is a method for a peer connected to the gossipsub router, but in `join` it `grafts` other peers.