### PR TITLE
Add initial deprecation notices

### DIFF
--- a/1-introduction.md
+++ b/1-introduction.md
@@ -5,6 +5,9 @@ While developing [IPFS, the InterPlanetary FileSystem](https://ipfs.io/), we cam
 
 In order to build this library, we focused on tackling problems independently, creating less complex solutions with powerful abstractions that, when composed, can offer an environment for a peer-to-peer application to work successfully.
 
+| ⚠️ Warning: parts of this document are incomplete and out of date. Please see [this issue](https://github.com/libp2p/specs/issues/156), and look for deprecation notices throughout. ⚠️ |
+| --- |
+
 ## 1.1 Motivation
 
 `libp2p` is the result of our collective experience of building a distributed system, in that it puts responsibility on developers to decide how they want an app to interoperate with others in the network, and favors configuration and extensibility instead of making assumptions about the network setup.

--- a/4-architecture.md
+++ b/4-architecture.md
@@ -1,6 +1,9 @@
 4 Architecture
 ==============
 
+| ⚠️ Warning: this section is incomplete, and parts of it are out of date. Please see [this issue](https://github.com/libp2p/specs/issues/156) to track progress on improving it. ⚠️ |
+| --- |
+
 `libp2p` was designed around the Unix Philosophy of creating small components that are easy to understand and test. These components should also be able to be swapped in order to accommodate different technologies or scenarios and also make it feasible to upgrade them over time.
 
 Although different peers can support different protocols depending on their capabilities, any peer can act as a dialer and/or a listener for connections from other peers, connections that once established can be reused from both ends, removing the distinction between clients and servers.

--- a/6-interfaces.md
+++ b/6-interfaces.md
@@ -1,6 +1,9 @@
 6 Interfaces
 ============
 
+| ⚠️ Warning: this section is incomplete, and parts of it are out of date. Please see [this issue](https://github.com/libp2p/specs/issues/156) to track progress on improving it. ⚠️ |
+| --- |
+
 `libp2p` is a collection of several protocols working together to offer a common solid interface that can talk with any other network addressable process. This is made possible by shimming currently existing protocols and implementations into a set of explicit interfaces: Peer Routing, Discovery, Stream Muxing, Transports, Connections and so on.
 
 ## 6.1 libp2p

--- a/7-properties.md
+++ b/7-properties.md
@@ -1,6 +1,9 @@
 7 Properties
 ============
 
+| ⚠️ Warning: this section is incomplete, and parts of it are out of date. Please see [this issue](https://github.com/libp2p/specs/issues/156) to track progress on improving it. ⚠️ |
+| --- |
+
 ## 7.1 Communication Model - Streams
 
 The Network layer handles all the problems of connecting to a peer, and exposes


### PR DESCRIPTION
This adds some warning text to a few sections of the main specs document to signal that we're aware of its shortcomings and are working on improving the spec. The odd formatting is me abusing github markdown's table syntax to draw some attention to the text.

So far I've just added a pretty generic notice to the intro and the sections that seem (to me) to be the most problematic: architecture, interfaces and properties.

There are other sections that need work as well, but those three need the most attention in the short term, IMO.

Questions:
- do we agree that these sections should be considered deprecated?
- what other parts of the spec should have "warning notices"?
- right now all the notices link to #156 - perhaps it would be better to make one issue per document to track ideas for improving each individually?
- what's the best way to prioritize improving the docs?

Another larger question is whether we should go big and focus on https://github.com/libp2p/specs/issues/110 vs rehabilitating the existing specs.