### PR TITLE
Adapt existing specs to lifecycle framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,15 +19,20 @@ libp2p has several [implementations][libp2p_implementations], with more in devel
 The main goal of this repository is to provide accurate reference documentation
 for the aspects of libp2p that are independent of language or implementation.
 This includes wire protocols, addressing conventions, and other "network level"
-concerns. 
+concerns.
+
+For user-facing documentation, please see https://docs.libp2p.io
+
+In addition to describing the current state of libp2p, the specs repository
+serves as a coordination point and a venue to drive future developments in
+libp2p. To participate in the evolution of libp2p via the specs process, please
+see the [Contributions section](#contributions).
 
 ## Status
 
-The specifications for libp2p are currently incomplete, and we have recently
-[defined a process][spec_lifecycle] for categorizing specs according to their
-maturity and status. Many of the existing specs linked below are not yet
-categorized according to this framework, however, they will soon be updated for
-consistency.
+The specifications for libp2p are currently incomplete, and we are working to
+address this by revising existing specs to ensure correctness and writing new
+specifications to detail currently unspecified parts of libp2p.
 
 This document replaces an earlier RFC, which still contains much useful
 information and is helpful for understanding the libp2p design philosophy. It is

--- a/discovery/mdns.md
+++ b/discovery/mdns.md
@@ -8,12 +8,13 @@
 
 Authors: [@richardschneider]
 
-Interest Group: [@yusefnapora], [@raulk], [@daviddias]
+Interest Group: [@yusefnapora], [@raulk], [@daviddias], [@jacobheun]
 
 [@richardschneider]: https://github.com/richardschneider
 [@yusefnapora]: https://github.com/yusefnapora
 [@raulk]: https://github.com/raulk
 [@daviddias]: https://github.com/daviddias
+[@jacobheun]: https://github.com/jacobheun
 
 See the [lifecycle document][lifecycle-spec] for context about maturity level
 and spec status.

--- a/discovery/mdns.md
+++ b/discovery/mdns.md
@@ -1,6 +1,48 @@
 # Multicast DNS (mDNS)
 
-Author: Richard Schneider (makaretu@gmail.com)
+> Local peer discovery with zero configuration using multicast DNS.
+
+| Lifecycle Stage | Maturity       | Status | Latest Revision |
+|-----------------|----------------|--------|-----------------|
+| 3A              | Recommendation | Active | r1, 2019-05-05  |
+
+Authors: [@richardschneider]
+
+Interest Group: [@yusefnapora], [@raulk], [@daviddias]
+
+[@richardschneider]: https://github.com/richardschneider
+[@yusefnapora]: https://github.com/yusefnapora
+[@raulk]: https://github.com/raulk
+[@daviddias]: https://github.com/daviddias
+
+See the [lifecycle document][lifecycle-spec] for context about maturity level
+and spec status.
+
+[lifecycle-spec]: https://github.com/libp2p/specs/blob/master/00-framework-01-spec-lifecycle.md
+
+## Table of Contents
+
+- [Multicast DNS (mDNS)](#multicast-dns-mdns)
+    - [Table of Contents](#table-of-contents)
+    - [Overview](#overview)
+    - [Definitions](#definitions)
+    - [Peer Discovery](#peer-discovery)
+        - [Request](#request)
+        - [Response](#response)
+    - [DNS Service Discovery](#dns-service-discovery)
+        - [Meta Query](#meta-query)
+        - [Find All Response](#find-all-response)
+        - [Gotchas](#gotchas)
+    - [Issues](#issues)
+    - [References](#references)
+    - [Worked Examples](#worked-examples)
+        - [Meta Query](#meta-query-1)
+            - [Question](#question)
+            - [Answer](#answer)
+        - [Find All Peers](#find-all-peers)
+            - [Question](#question-1)
+            - [Answer](#answer-1)
+            - [Additional Records](#additional-records)
 
 ## Overview
 

--- a/identify/README.md
+++ b/identify/README.md
@@ -1,7 +1,45 @@
 # Identify v1.0.0
 
-The identify protocol is used to exchange basic information with other peers
-in the network, including addresses, public keys, and capabilities.
+> The identify protocol is used to exchange basic information with other peers
+> in the network, including addresses, public keys, and capabilities.
+
+| Lifecycle Stage | Maturity Level | Status | Latest Revision |
+|-----------------|----------------|--------|-----------------|
+| 3A              | Recommendation | Active | r0, 2019-05-01  |
+
+Authors: [@vyzo]
+
+Interest Group: [@yusefnapora], [@tomaka], [@richardschneider], [@Stebalien], [@bigs]
+
+[@vyzo]: https://github.com/vyzo
+[@yusefnapora]: https://github.com/yusefnapora
+[@tomaka]: https://github.com/tomaka
+[@richardschneider]: https://github.com/richardschneider
+[@Stebalien]: https://github.com/Stebalien
+[@bigs]: https://github.com/bigs
+
+See the [lifecycle document][lifecycle-spec] for context about maturity level
+and spec status.
+
+[lifecycle-spec]: https://github.com/libp2p/specs/blob/master/00-framework-01-spec-lifecycle.md
+
+## Table of Contents
+
+- [Identify v1.0.0](#identify-v100)
+    - [Table of Contents](#table-of-contents)
+    - [Overview](#overview)
+        - [`identify`](#identify)
+        - [`identify/push`](#identifypush)
+    - [The Identify Message](#the-identify-message)
+        - [protocolVersion](#protocolversion)
+        - [agentVersion](#agentversion)
+        - [publicKey](#publickey)
+        - [listenAddrs](#listenaddrs)
+        - [observedAddr](#observedaddr)
+        - [protocols](#protocols)
+
+
+## Overview
 
 There are two variations of the identify protocol, `identify` and `identify/push`.
 

--- a/mplex/README.md
+++ b/mplex/README.md
@@ -1,6 +1,42 @@
 # mplex
 
-> This repo contains the spec of mplex, the friendly Stream Multiplexer (that works in 3 languages!)
+> The spec for the friendly Stream Multiplexer (that works in 3 languages!)
+
+| Lifecycle Stage | Maturity       | Status | Latest Revision |
+|-----------------|----------------|--------|-----------------|
+| 3A              | Recommendation | Active | r0, 2018-10-10  |
+
+Authors: [@daviddias], [@Stebalien], [@tomaka]
+
+Interest Group: [@yusefnapora], [@richardschneider], [@jacobheun]
+
+[@daviddias]: https://github.com/daviddias
+[@Stebalien]: https://github.com/Stebalien
+[@tomaka]: https://github.com/tomaka
+[@yusefnapora]: https://github.com/yusefnapora
+[@richardschneider]: https://github.com/richardschneider
+[@jacobheun]: https://github.com/jacobheun
+
+See the [lifecycle document][lifecycle-spec] for context about maturity level
+and spec status.
+
+[lifecycle-spec]: https://github.com/libp2p/specs/blob/master/00-framework-01-spec-lifecycle.md
+
+## Table of Contents
+
+- [mplex](#mplex)
+    - [Table of Contents](#table-of-contents)
+    - [Overview](#overview)
+    - [Message format](#message-format)
+        - [Flag Values](#flag-values)
+    - [Protocol](#protocol)
+        - [Opening a new stream](#opening-a-new-stream)
+        - [Writing to a stream](#writing-to-a-stream)
+        - [Closing a stream](#closing-a-stream)
+        - [Resetting a stream](#resetting-a-stream)
+    - [Implementation notes](#implementation-notes)
+
+## Overview
 
 Mplex is a Stream Multiplexer protocol used by js-ipfs and go-ipfs in their implementations. The origins of this protocol are based in [multiplex](https://github.com/maxogden/multiplex), the JavaScript-only Stream Multiplexer. After many battle field tests, we felt the need to improve and fix some of its bugs and mechanics, resulting on this new version used by libp2p.
 

--- a/pnet/Private-Networks-PSK-V1.md
+++ b/pnet/Private-Networks-PSK-V1.md
@@ -1,6 +1,28 @@
-## Pre-shared Key Based Private Networks in IPFS
+## Pre-shared Key Based Private Networks in libp2p
 
-This document describes the first version of private networks (PN) featured in IPFS.
+| Lifecycle Stage | Maturity       | Status | Latest Revision |
+|-----------------|----------------|--------|-----------------|
+| 3A              | Recommendation | Active | r0, 2017-02-17  |
+
+
+Authors: [@Kubuxu]
+
+Interest Group: [@yusefnapora], [@jacobheun], [@lgierth], [@daviddias]
+
+[@Kubuxu]: https://github.com/Kubuxu
+[@yusefnapora]: https://github.com/yusefnapora
+[@jacobheun]: https://github.com/jacobheun
+[@lgierth]: https://github.com/lgierth
+[@daviddias]: https://github.com/daviddias
+
+See the [lifecycle document][lifecycle-spec] for context about maturity level
+and spec status.
+
+[lifecycle-spec]: https://github.com/libp2p/specs/blob/master/00-framework-01-spec-lifecycle.md
+
+---
+
+This document describes the first version of private networks (PN) featured in libp2p.
 
 For the first implementation, only pre-shared key (PSK) functionality is available, as the Public Key Infrastructure approach is much more complex and requires more technical preparation.
 

--- a/pubsub/README.md
+++ b/pubsub/README.md
@@ -8,7 +8,7 @@
 
 Authors: [@whyrusleeping]
 
-Interest Group: [@yusefnapora], [@raulk], [@vyzo], [@Stebalien], [@jamesray1]
+Interest Group: [@yusefnapora], [@raulk], [@vyzo], [@Stebalien], [@jamesray1], [@vasco-santos]
 
 [@whyrusleeping]: https://github.com/whyrusleeping
 [@yusefnapora]: https://github.com/yusefnapora
@@ -16,6 +16,7 @@ Interest Group: [@yusefnapora], [@raulk], [@vyzo], [@Stebalien], [@jamesray1]
 [@vyzo]: https://github.com/vyzo
 [@Stebalien]: https://github.com/Stebalien
 [@jamesray1]: https://github.com/jamesray1
+[@vasco-santos]: https://github.com/vasco-santos
 
 See the [lifecycle document][lifecycle-spec] for context about maturity level
 and spec status.

--- a/pubsub/README.md
+++ b/pubsub/README.md
@@ -1,9 +1,49 @@
 # PubSub interface for libp2p
 
-Revision: draft 2, 2019-02-01
+> Generalized publish/subscribe interface for libp2p.
 
-Authors:
-- whyrusleeping (why@ipfs.io)
+| Lifecycle Stage | Maturity       | Status | Latest Revision |
+|-----------------|----------------|--------|-----------------|
+| 3A              | Recommendation | Active | r2, 2019-02-01  |
+
+Authors: [@whyrusleeping]
+
+Interest Group: [@yusefnapora], [@raulk], [@vyzo], [@Stebalien], [@jamesray1]
+
+[@whyrusleeping]: https://github.com/whyrusleeping
+[@yusefnapora]: https://github.com/yusefnapora
+[@raulk]: https://github.com/raulk
+[@vyzo]: https://github.com/vyzo
+[@Stebalien]: https://github.com/Stebalien
+[@jamesray1]: https://github.com/jamesray1
+
+See the [lifecycle document][lifecycle-spec] for context about maturity level
+and spec status.
+
+[lifecycle-spec]: https://github.com/libp2p/specs/blob/master/00-framework-01-spec-lifecycle.md
+
+## Table of Contents
+
+- [PubSub interface for libp2p](#pubsub-interface-for-libp2p)
+    - [Table of Contents](#table-of-contents)
+    - [Overview](#overview)
+    - [Implementations](#implementations)
+    - [The RPC](#the-rpc)
+    - [The Message](#the-message)
+    - [Message Signing](#message-signing)
+    - [The Topic Descriptor](#the-topic-descriptor)
+        - [AuthOpts](#authopts)
+            - [AuthMode 'NONE'](#authmode-none)
+            - [AuthMode 'KEY'](#authmode-key)
+            - [AuthMode 'WOT'](#authmode-wot)
+        - [EncOpts](#encopts)
+            - [EncMode 'NONE'](#encmode-none)
+            - [EncMode 'SHAREDKEY'](#encmode-sharedkey)
+            - [EncMode 'WOT'](#encmode-wot)
+    - [Topic Validation](#topic-validation)
+
+
+## Overview
 
 This is the specification for generalized pubsub over libp2p. Pubsub in libp2p
 is currently still experimental and this specification is subject to change.

--- a/pubsub/gossipsub/README.md
+++ b/pubsub/gossipsub/README.md
@@ -7,7 +7,8 @@
 
 Authors: [@vyzo]
 
-Interest Group: [@yusefnapora], [@raulk], [@whyrusleeping], [@Stebalien], [@jamesray1]
+Interest Group: [@yusefnapora], [@raulk], [@whyrusleeping], [@Stebalien],
+[@jamesray1], [@vasco-santos]
 
 [@whyrusleeping]: https://github.com/whyrusleeping
 [@yusefnapora]: https://github.com/yusefnapora
@@ -15,6 +16,7 @@ Interest Group: [@yusefnapora], [@raulk], [@whyrusleeping], [@Stebalien], [@jame
 [@vyzo]: https://github.com/vyzo
 [@Stebalien]: https://github.com/Stebalien
 [@jamesray1]: https://github.com/jamesray1
+[@vasco-santos]: https://github.com/vasco-santos
 
 See the [lifecycle document][lifecycle-spec] for context about maturity level
 and spec status.

--- a/pubsub/gossipsub/README.md
+++ b/pubsub/gossipsub/README.md
@@ -1,8 +1,27 @@
 # gossipsub: An extensible baseline pubsub protocol
 
-Revision: r1; 2018-08-29
+| Lifecycle Stage | Maturity       | Status | Latest Revision |
+|-----------------|----------------|--------|-----------------|
+| 3A              | Recommendation | Active | r1, 2018-08-29  |
 
-Author: vyzo
+
+Authors: [@vyzo]
+
+Interest Group: [@yusefnapora], [@raulk], [@whyrusleeping], [@Stebalien], [@jamesray1]
+
+[@whyrusleeping]: https://github.com/whyrusleeping
+[@yusefnapora]: https://github.com/yusefnapora
+[@raulk]: https://github.com/raulk
+[@vyzo]: https://github.com/vyzo
+[@Stebalien]: https://github.com/Stebalien
+[@jamesray1]: https://github.com/jamesray1
+
+See the [lifecycle document][lifecycle-spec] for context about maturity level
+and spec status.
+
+[lifecycle-spec]: https://github.com/libp2p/specs/blob/master/00-framework-01-spec-lifecycle.md
+
+---
 
 This is the specification for an extensible baseline pubsub protocol,
 based on randomized topic meshes and gossip. It is a general purpose

--- a/pubsub/gossipsub/episub.md
+++ b/pubsub/gossipsub/episub.md
@@ -6,7 +6,7 @@
 
 Authors: [@vyzo]
 
-Interest Group: [@yusefnapora], [@raulk], [@vyzo], [@Stebalien], [@jamesray1]
+Interest Group: [@yusefnapora], [@raulk], [@vyzo], [@Stebalien], [@jamesray1], [@vasco-santos]
 
 [@whyrusleeping]: https://github.com/whyrusleeping
 [@yusefnapora]: https://github.com/yusefnapora
@@ -14,6 +14,7 @@ Interest Group: [@yusefnapora], [@raulk], [@vyzo], [@Stebalien], [@jamesray1]
 [@vyzo]: https://github.com/vyzo
 [@Stebalien]: https://github.com/Stebalien
 [@jamesray1]: https://github.com/jamesray1
+[@vasco-santos]: https://github.com/vasco-santos
 
 Author's note:
 - This is based on an earlier research draft about an epidemic broadcast protocol

--- a/pubsub/gossipsub/episub.md
+++ b/pubsub/gossipsub/episub.md
@@ -1,10 +1,19 @@
 # Episub: Proximity Aware Epidemic PubSub for libp2p
 
-Revision: draft 1, 2018-06-28
+| Lifecycle Stage | Maturity      | Status | Latest Revision |
+|-----------------|---------------|--------|-----------------|
+| 1A              | Working Draft | Active | r1, 2018-06-28  |
 
-Author: vyzo
+Authors: [@vyzo]
 
-Editor: jamesray1
+Interest Group: [@yusefnapora], [@raulk], [@vyzo], [@Stebalien], [@jamesray1]
+
+[@whyrusleeping]: https://github.com/whyrusleeping
+[@yusefnapora]: https://github.com/yusefnapora
+[@raulk]: https://github.com/raulk
+[@vyzo]: https://github.com/vyzo
+[@Stebalien]: https://github.com/Stebalien
+[@jamesray1]: https://github.com/jamesray1
 
 Author's note:
 - This is based on an earlier research draft about an epidemic broadcast protocol
@@ -12,6 +21,8 @@ Author's note:
   It serves as reference for the design of episub, an extended gossipsub router
   optimized for single source multicast and scenarios with a few fixed sources
   broadcasting to a large number of clients in a topic.
+
+--- 
 
 <!-- toc -->
 

--- a/relay/README.md
+++ b/relay/README.md
@@ -2,6 +2,26 @@
 
 > Circuit Switching for libp2p, also known as TURN or Relay in Networking literature.
 
+| Lifecycle Stage | Maturity       | Status | Latest Revision |
+|-----------------|----------------|--------|-----------------|
+| 3A              | Recommendation | Active | r1, 2018-06-03  |
+
+Authors: [@daviddias]
+
+Interest Group: [@lgierth], [@hsanjuan], [@jamesray1], [@vyzo], [@yusefnapora]
+
+[@daviddias]: https://github.com/daviddias
+[@lgierth]: https://github.com/lgierth
+[@hsanjuan]: https://github.com/hsanjuan
+[@jamesray1]: https://github.com/jamesray1
+[@vyzo]: https://github.com/vyzo
+[@yusefnapora]: https://github.com/yusefnapora
+
+See the [lifecycle document][lifecycle-spec] for context about maturity level
+and spec status.
+
+[lifecycle-spec]: https://github.com/libp2p/specs/blob/master/00-framework-01-spec-lifecycle.md
+
 ## Implementations
 
 - [js-libp2p-circuit](https://github.com/libp2p/js-libp2p-circuit)

--- a/rendezvous/README.md
+++ b/rendezvous/README.md
@@ -1,8 +1,26 @@
 # Rendezvous Protocol
 
-Author: vyzo
+| Lifecycle Stage | Maturity      | Status | Latest Revision |
+|-----------------|---------------|--------|-----------------|
+| 1A              | Working Draft | Active | r1, 2019-01-18  |
 
-Revision: DRAFT; 2019-01-18
+Authors: [@vyzo]
+
+Interest Group: [@daviddias], [@whyrusleeping], [@Stebalien], [@jacobheun], [@yusefnapora]
+
+[@vyzo]: https://github.com/vyzo
+[@daviddias]: https://github.com/daviddias
+[@whyrusleeping]: https://github.com/whyrusleeping
+[@Stebalien]: https://github.com/Stebalien
+[@jacobheun]: https://github.com/jacobheun
+[@yusefnapora]: https://github.com/yusefnapora
+
+See the [lifecycle document][lifecycle-spec] for context about maturity level
+and spec status.
+
+[lifecycle-spec]: https://github.com/libp2p/specs/blob/master/00-framework-01-spec-lifecycle.md
+
+## Overview
 
 The protocol described in this specification is intended to provide a
 lightweight mechanism for generalized peer discovery. It can be used

--- a/tls/tls.md
+++ b/tls/tls.md
@@ -1,5 +1,36 @@
 # libp2p TLS Handshake
 
+| Lifecycle Stage | Maturity                 | Status | Latest Revision |
+|-----------------|--------------------------|--------|-----------------|
+| 2A              | Candidate Recommendation | Active | r0, 2019-03-23  |
+
+Authors: [@marten-seemann]
+
+Interest Group: [@Stebalien], [@jacobheun], [@raulk], [@Kubuxu], [@yusefnapora]
+
+[@marten-seemann]: https://github.com/marten-seemann
+[@Stebalien]: https://github.com/Stebalien
+[@jacobheun]: https://github.com/jacobheun
+[@raulk]: https://github.com/raulk
+[@Kubuxu]: https://github.com/Kubuxu
+[@yusefnapora]: https://github.com/yusefnapora
+
+
+See the [lifecycle document][lifecycle-spec] for context about maturity level
+and spec status.
+
+[lifecycle-spec]: https://github.com/libp2p/specs/blob/master/00-framework-01-spec-lifecycle.md
+
+## Table of Contents
+
+- [libp2p TLS Handshake](#libp2p-tls-handshake)
+    - [Table of Contents](#table-of-contents)
+    - [Introduction](#introduction)
+    - [Handshake Protocol](#handshake-protocol)
+    - [Peer Authentication](#peer-authentication)
+        - [libp2p Public Key Extension](#libp2p-public-key-extension)
+    - [Future Extensibility](#future-extensibility)
+
 ## Introduction
 
 This document describes how [TLS 1.3](https://tools.ietf.org/html/rfc8446) is used to secure libp2p connections. Endpoints authenticate to their peers by encoding their public key into a x509 certificate extension. The protocol described here allows peers to use arbitrary key types, not constrained to those for which signing of a x509 certificates is specified.


### PR DESCRIPTION
Hey all, I've been going through the existing specs and trying to see how they fit to the lifecycle / maturity framework from #169.

Here's what I came up with:

| Spec       | Stage | Authors                         | Interest Group                                     |
|------------|-------|---------------------------------|----------------------------------------------------|
| mdns       | 3A    | @richardschneider               | @raulk, @daviddias                                 |
| identify   | 3A    | @vyzo                           | @tomaka, @richardschneider, @Stebalien, @bigs      |
| mplex      | 3A    | @daviddias, @Stebalien, @tomaka | @richardschneider, @jacobheun                      |
| pnet       | 3A    | @Kubuxu                         | @jacobheun, @lgierth, @daviddias                   |
| pubsub     | 3A    | @whyrusleeping                  | @raulk, @vyzo, @Stebalien, @jamesray1              |
| gossipsub  | 3A    | @vyzo                           | @raulk, @whyrusleeping, @Stebalien, @jamesray1     |
| episub     | 3A    | @vyzo                           | @raulk, @whyrusleeping, @Stebalien, @jamesray1     |
| relay      | 3A    | @daviddias                      | @lgierth, @hsanjuan, @jamesray1, @vyzo             |
| rendezvous | 1A    | @vyzo                           | @daviddias, @whyrusleeping, @Stebalien, @jacobheun |
| tls        | 2A    | @marten-seemann                 | @Stebalien, @jacobheun, @raulk, @Kubuxu            |

I'm also in all the Interest Groups, but I got tired of typing my own handle 😛

I mostly grabbed people out of the PR discussions to put into interest groups. If you see yourself in any and don't want to be, please speak up!

Likewise, @libp2p/go-team, @libp2p/javascript-team, @libp2p/rust-team if you *dont* see yourself and wouldn't mind joining an interest group, let me know.

My feeling is that the Interest Groups for these specs will be pretty low-overhead in terms of attention needed, at least compared to new and developing specs.

I categorized everything as 3A (Recommendation/Active) except for rendezvous (since it seems to still be a working draft), and TLS 1.3, which I marked as a Candidate Recommendation since it's go-only at the moment.

All feedback welcome :)