### PR TITLE
demote mDNS spec to Working Draft.

### DIFF
--- a/discovery/mdns.md
+++ b/discovery/mdns.md
@@ -4,7 +4,7 @@
 
 | Lifecycle Stage | Maturity       | Status | Latest Revision |
 |-----------------|----------------|--------|-----------------|
-| 3A              | Recommendation | Active | r1, 2019-05-05  |
+| 0A              | Working Draft  | Active | r1, 2019-05-05  |
 
 Authors: [@richardschneider]
 

--- a/discovery/mdns.md
+++ b/discovery/mdns.md
@@ -4,7 +4,7 @@
 
 | Lifecycle Stage | Maturity       | Status | Latest Revision |
 |-----------------|----------------|--------|-----------------|
-| 0A              | Working Draft  | Active | r1, 2019-05-05  |
+| 1A              | Working Draft  | Active | r1, 2019-05-05  |
 
 Authors: [@richardschneider]
 


### PR DESCRIPTION
A Recommendation has at least TWO implementations demonstrating interoperability.

A Candidate Recommendation has ONE implementation serving as the Reference Implementation.

This mDNS spec currently has no known libp2p implementations.

mDNS support in go-libp2p and js-libp2p are non-compliant because they predate this spec, and this spec introduces breakages.

Hence, as per above, we demote this specification to the maturity stage it belongs to: Working Draft.