### PR TITLE
Add a limit of 8MiB to secio messages size

### DIFF
--- a/secio/README.md
+++ b/secio/README.md
@@ -124,7 +124,8 @@ negotiation.
 ### Message framing
 
 All messages sent over the wire are prefixed with the message length in bytes,
-encoded as an unsigned 32-bit Big Endian integer.
+encoded as an unsigned 32-bit Big Endian integer. The message length should always
+be inferior to 0x800000 (or 8MiB).
 
 ### Proposal Generation
 


### PR DESCRIPTION
This is apparently already the case in practice, but we should add it to the specs.