### PR TITLE
Sign SubjectPublicKeyInfo instead of the raw public key

### DIFF
--- a/tls/tls.md
+++ b/tls/tls.md
@@ -72,7 +72,7 @@ In order to prove ownership of its host key, an endpoint sends two values:
 
 The public host key allows the peer to calculate the peer ID of the peer it is connecting to. Clients MUST verify that the peer ID derived from the certificate matches the peer ID they intended to connect to, and MUST abort the connection if there is a mismatch.
 
-The peer signs the concatenation of the string `libp2p-tls-handshake:` and the public key that it used to generate the certificate carrying the libp2p Public Key Extension, using its private host key. This signature provides cryptographic proof that the peer was in possession of the private host key at the time the certificate was signed. Peers MUST verify the signature, and abort the connection attempt if signature verification fails.
+The peer signs the concatenation of the string `libp2p-tls-handshake:` and the `SubjectPublicKeyInfo` of the certificate carrying the libp2p Public Key Extension, using its private host key. This signature provides cryptographic proof that the peer was in possession of the private host key at the time the certificate was signed. Peers MUST verify the signature, and abort the connection attempt if signature verification fails.
 
 The public host key and the signature are ANS.1-encoded into the SignedKey data structure, which is carried in the libp2p Public Key Extension. The libp2p Public Key Extension is a X.509 extension with the Object Identier `1.3.6.1.4.1.53594.1.1`, [allocated by IANA to the libp2p project at Protocol Labs](https://www.iana.org/assignments/enterprise-numbers/enterprise-numbers).
 


### PR DESCRIPTION
The `SubjectPublicKeyInfo` contains not only the key, but also the
algorithm.  It is theoretically possible for two different keys to have
the same public key, but different algorithms, and one should not be
accepted where the other was intended.