### PR TITLE
remove Noise Pipes and padding within payloads

### DIFF
--- a/noise/README.md
+++ b/noise/README.md
@@ -202,8 +202,7 @@ MUST be discarded immediately.
 
 Any early data provided to noise-libp2p MUST be included in the [handshake
 payload](#the-libp2p-handshake-payload) as a byte string without alteration by
-the noise-libp2p implementation, and a valid signature of the early data MUST be
-included as described below.
+the noise-libp2p implementation.
 
 #### The libp2p Handshake Payload
 


### PR DESCRIPTION
This PR removes Noise Pipes from the noise-libp2p spec, and also removes the padding within encrypted payloads. 

Apologies to anyone who was waiting on this or was confused about the current state of the spec; this took me a lot longer than it should have :)

These changes bring the spec in line with the current Go and JavaScript implementations.

cc noise-libp2p IG: @raulk, @tomaka, @romanb, @shahankhatch, @Mikerah,
@djrtwo, @dryajov, @mpetrunic, @AgeManning, @morrigan, @araskachoi,
@mhchia