### PR TITLE
promote noise-libp2p spec to maturity stage 3A

### DIFF
--- a/noise/README.md
+++ b/noise/README.md
@@ -5,7 +5,7 @@
 
 | Lifecycle Stage | Maturity      | Status | Latest Revision |
 |-----------------|---------------|--------|-----------------|
-| 1A              | Working Draft | Active | r2, 2020-03-30  |
+| 3A              | Working Draft | Active | r2, 2020-03-30  |
 
 Authors: [@yusefnapora]
 


### PR DESCRIPTION
This spec now satisfies the conditions to be considered an ACTIVE RECOMMENDATION.

The two known interoperable implementations are:

* go-libp2p-noise: https://github.com/libp2p/go-libp2p-noise
* js-libp2p-noise: https://github.com/NodeFactoryIo/js-libp2p-noise

---

ping @raulk, @tomaka, @romanb, @shahankhatch, @Mikerah, @djrtwo, @dryajov, @mpetrunic, @AgeManning, @morrigan, @araskachoi, @mhchia

Conformant to our [spec lifecycle process](https://github.com/libp2p/specs/blob/master/00-framework-01-spec-lifecycle.md), you have 10 days to dispute the promotion ;-)