### PR TITLE
Update gossipsub v1.1 spec

### DIFF
--- a/pubsub/gossipsub/gossipsub-v1.1.md
+++ b/pubsub/gossipsub/gossipsub-v1.1.md
@@ -29,7 +29,7 @@ See the [lifecycle document][lifecycle-spec] for context about maturity level an
 - [Overview](#overview)
 - [Protocol extensions](#protocol-extensions)
   - [Explicit Peering Agreements](#explicit-peering-agreements)
-  - [Peer Exchange on PRUNE](#peer-exchange-on-prune)
+  - [PRUNE Backoff and Peer Exchange](#prune-backoff-and-peer-exchange)
     - [Protobuf](#protobuf)
   - [Flood Publishing](#flood-publishing)
   - [Adaptive Gossip Dissemination](#adaptive-gossip-dissemination)

--- a/pubsub/gossipsub/gossipsub-v1.1.md
+++ b/pubsub/gossipsub/gossipsub-v1.1.md
@@ -97,7 +97,9 @@ for the action, and penalize the peer through P₇ (see [Peer Scoring](#peer-sco
 The recommended duration for the backoff period is 1 minute, while the recommended number of peers
 to exchange is larger than `D_hi` so that the pruned peer can reliably form a full mesh.
 In order to correctly synchronize the two peers, the pruning peer should include the backoff period
-in the PRUNE message.
+in the PRUNE message. The peer has to wait the full backoff period before attempting to graft again,
+otherwise it risks getting its graft rejected and being penalized in its score if it attempts to
+graft too early.
 
 In order to implement PX, we extend the `PRUNE` control message to include an optional set of
 peers the pruned peer can connect to. This set of peers includes the Peer ID and a [_signed_ peer

--- a/pubsub/gossipsub/gossipsub-v1.1.md
+++ b/pubsub/gossipsub/gossipsub-v1.1.md
@@ -587,6 +587,16 @@ In order counter spam that elicits responses and consumes resources, some measur
   in gossipsub v1.0 the router always responds to `IWANT` messages when the message in the cache.
   In gossipsub v1.1 the router responds a limited number of times to each peer so that `IWANT` spam
   does not cause a signficant drain of resources.
+- `IHAVE` messages are capped to a certain number of `IHAVE` messages and aggregate number of message
+  IDs advertised per heartbeat, in order to reduce the exposure to floods. If more `IHAVE` advertisements
+  are received than the limit (or more messages are advertised than the limit), then additional `IHAVE`
+  messages are ignored.
+- In flight `IWANT` requests, sent as a response to an `IHAVE` advertisement, are probabilistically tracked.
+  For each `IHAVE` advertisement which elicits an `IWANT` request, the router tracks a random message ID
+  within the advertised set. If the message is not received (from any peer) within a period of time, then
+  a behavioural penalty is applied to the advertising peer through `P₇`.
+  This measure helps protect against spam `IHAVE` floods by quickly flagging and graylisting peers
+  who advertise bogus message IDs and/or do not follow up to the `IWANT` requests.
 - Invalid message spam, either directly transmitted or as a response to an `IHAVE` message is
   penalized by the score function. A peer transmitting lots of spam will quickly get graylisted,
   reducing the surface of spam-induced computation (eg validation). The application can take

--- a/pubsub/gossipsub/gossipsub-v1.1.md
+++ b/pubsub/gossipsub/gossipsub-v1.1.md
@@ -2,7 +2,7 @@
 
 | Lifecycle Stage | Maturity       | Status | Latest Revision |
 |-----------------|----------------|--------|-----------------|
-| 1A              | Draft          | Active | r3, 2020-04-28  |
+| 1A              | Draft          | Active | r4, 2020-05-11  |
 
 
 Authors: [@vyzo]


### PR DESCRIPTION
Updates the gsv1.1 spec:
- Prune backoff is now specified aspart of the protobuf `PRUNE` message.
- P4 is now quadratic
- P7 is introduced for behavioural penalties
- IHAVE flood spam protection measures are specified