### PR TITLE
Promote gossipsub v1.1 spec to Candidate Recommendation

### DIFF
--- a/pubsub/gossipsub/gossipsub-v1.1.md
+++ b/pubsub/gossipsub/gossipsub-v1.1.md
@@ -1,8 +1,8 @@
 # gossipsub v1.1: Security extensions to improve on attack resilience and bootstrapping
 
-| Lifecycle Stage | Maturity       | Status | Latest Revision |
-|-----------------|----------------|--------|-----------------|
-| 1A              | Draft          | Active | r4, 2020-05-11  |
+| Lifecycle Stage | Maturity                  | Status | Latest Revision |
+|-----------------|---------------------------|--------|-----------------|
+| 2A              | Candidate Recommendation  | Active | r4, 2020-05-11  |
 
 
 Authors: [@vyzo]


### PR DESCRIPTION
Reference implementation is https://github.com/libp2p/go-libp2p-pubsub/, conformant to the promoted spec as of https://github.com/libp2p/go-libp2p-pubsub/pull/263, and follow-ups.