### PR TITLE
Fix number of global score params

### DIFF
--- a/pubsub/gossipsub/gossipsub-v1.1.md
+++ b/pubsub/gossipsub/gossipsub-v1.1.md
@@ -248,7 +248,7 @@ configured a larger mesh than the default parameters.
 
 #### The Score Function
 
-The score function is a weighted mix of parameters, 4 of them per topic and 2 of them globally
+The score function is a weighted mix of parameters, 4 of them per topic and 3 of them globally
 applicable.
 ```
 Score(p) = TopicCap(Σtᵢ*(w₁(tᵢ)*P₁(tᵢ) + w₂(tᵢ)*P₂(tᵢ) + w₃(tᵢ)*P₃(tᵢ) + w₃b(tᵢ)*P₃b(tᵢ) + w₄(tᵢ)*P₄(tᵢ))) + w₅*P₅ + w₆*P₆ + w₇*P₇


### PR DESCRIPTION
Fixes a number of global score parameters specified in The Score Function section. It's been set to `2` while there are `3` of them in the score function.