### PR TITLE
Update gossipsub v1.1 spec with recommendations for network bootstrapping

### DIFF
--- a/pubsub/gossipsub/gossipsub-v1.1.md
+++ b/pubsub/gossipsub/gossipsub-v1.1.md
@@ -633,7 +633,7 @@ In order counter spam that elicits responses and consumes resources, some measur
 An important issue to consider when deploying gossipsub is the peer discovery mechanism,
 which must provide a secure way of discovering new peers.
 Prior to gossipsub v1.1, operators were required to utilize an external peer discovery
-mechanism; with gossipsub v1.1 this is now entirely optional and the network can bootstrap
+mechanism to locate peers meshing in particular topics; with gossipsub v1.1 this is now entirely optional and the network can bootstrap
 purely through a small set of network entry points (bootstrappers) by utilizing Peer Exchange.
 
 In order to successfully bootstrap the network without a discovery service, network operators

--- a/pubsub/gossipsub/gossipsub-v1.1.md
+++ b/pubsub/gossipsub/gossipsub-v1.1.md
@@ -2,7 +2,7 @@
 
 | Lifecycle Stage | Maturity       | Status | Latest Revision |
 |-----------------|----------------|--------|-----------------|
-| 1A              | Draft          | Active | r5, 2020-05-18  |
+| 1A              | Draft          | Active | r6, 2020-05-21  |
 
 
 Authors: [@vyzo]
@@ -49,6 +49,7 @@ See the [lifecycle document][lifecycle-spec] for context about maturity level an
     - [Extended Validators](#extended-validators)
   - [Overview of New Parameters](#overview-of-new-parameters)
   - [Spam Protection Measures](#spam-protection-measures)
+  - [Recommendations for Network Operators](#recommendations-for-network-operators)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -626,3 +627,28 @@ In order counter spam that elicits responses and consumes resources, some measur
   penalized by the score function. A peer transmitting lots of spam will quickly get graylisted,
   reducing the surface of spam-induced computation (eg validation). The application can take
   further steps and blacklist the peer if the spam persists after the negative score decays.
+
+### Recommendations for Network Operators
+
+An important issue to consider when deploying gossipsub is the peer discovery mechanism,
+which must provide a secure way of discovering new peers.
+Prior to gossipsub v1.1, operators were required to utilize an external peer discovery
+mechanism; with gossipsub v1.1 this is now entirely optional and the network can bootstrap
+purely through a small set of network entry points (bootstrappers) by utilizing Peer Exchange.
+
+In order to successfully bootstrap the network without a discovery service, network operators
+should
+- Create and operate a set of bootstrapper nodes, that are known within client software.
+- The bootstrappers should be configured without a mesh (ie set `D=Dlo=Dhi=Dout=0`)
+  and with Peer Exchange enabled, utilizing Signed Peer Records.
+- Client software should assign a high application specific score to the bootstrappers and
+  set the `AcceptPXThreshold` to a high enough value attainable only by the bootstrappers.
+
+In this manner, the bootstrappers act purely as gossip and peer exchange nodes that facilitate
+the formation and maintenance of the network.
+Note that the score function is still present in the bootstrappers, which ensures that invalid
+messages, colocation, and behavioural penalties apply to misbehaving nodes such that they do
+not receive PX or are advertised to the rest of the network.
+In addition, network operators may configure the application specific scoring function such
+that the bootstrappers enforce further constraints into accepting new nodes (eg protocol
+handshakes, staked participation, and so on).

--- a/pubsub/gossipsub/gossipsub-v1.1.md
+++ b/pubsub/gossipsub/gossipsub-v1.1.md
@@ -641,7 +641,7 @@ should
 - Create and operate a set of stable bootstrapper nodes, whose addresses are known ahead of time by the application.
 - The bootstrappers should be configured without a mesh (ie set `D=Dlo=Dhi=Dout=0`)
   and with Peer Exchange enabled, utilizing Signed Peer Records.
-- Client software should assign a high application specific score to the bootstrappers and
+- The application should assign a high application-specific score to the bootstrappers and
   set the `AcceptPXThreshold` to a high enough value attainable only by the bootstrappers.
 
 In this manner, the bootstrappers act purely as gossip and peer exchange nodes that facilitate

--- a/pubsub/gossipsub/gossipsub-v1.1.md
+++ b/pubsub/gossipsub/gossipsub-v1.1.md
@@ -649,6 +649,6 @@ the formation and maintenance of the network.
 Note that the score function is still present in the bootstrappers, which ensures that invalid
 messages, colocation, and behavioural penalties apply to misbehaving nodes such that they do
 not receive PX or are advertised to the rest of the network.
-In addition, network operators may configure the application specific scoring function such
+In addition, network operators may configure the application-specific scoring function such
 that the bootstrappers enforce further constraints into accepting new nodes (eg protocol
 handshakes, staked participation, and so on).

--- a/pubsub/gossipsub/gossipsub-v1.1.md
+++ b/pubsub/gossipsub/gossipsub-v1.1.md
@@ -633,8 +633,8 @@ In order counter spam that elicits responses and consumes resources, some measur
 An important issue to consider when deploying gossipsub is the peer discovery mechanism,
 which must provide a secure way of discovering new peers.
 Prior to gossipsub v1.1, operators were required to utilize an external peer discovery
-mechanism to locate peers meshing in particular topics; with gossipsub v1.1 this is now entirely optional and the network can bootstrap
-purely through a small set of network entry points (bootstrappers) by utilizing Peer Exchange. In other words, gossipsub 1.1 is now self-sufficient in this regard, as long as the node manages to find at least one peer meshing in the topic of interest.
+mechanism to locate peers paritcipating in particular topics; with gossipsub v1.1 this is now entirely optional and the network can bootstrap
+purely through a small set of network entry points (bootstrappers) by utilizing Peer Exchange. In other words, gossipsub 1.1 is now self-sufficient in this regard, as long as the node manages to find at least one peer participating in the topic of interest.
 
 In order to successfully bootstrap the network without a discovery service, network operators
 should

--- a/pubsub/gossipsub/gossipsub-v1.1.md
+++ b/pubsub/gossipsub/gossipsub-v1.1.md
@@ -634,7 +634,7 @@ An important issue to consider when deploying gossipsub is the peer discovery me
 which must provide a secure way of discovering new peers.
 Prior to gossipsub v1.1, operators were required to utilize an external peer discovery
 mechanism to locate peers meshing in particular topics; with gossipsub v1.1 this is now entirely optional and the network can bootstrap
-purely through a small set of network entry points (bootstrappers) by utilizing Peer Exchange.
+purely through a small set of network entry points (bootstrappers) by utilizing Peer Exchange. In other words, gossipsub 1.1 is now self-sufficient in this regard, as long as the node manages to find at least one peer meshing in the topic of interest.
 
 In order to successfully bootstrap the network without a discovery service, network operators
 should

--- a/pubsub/gossipsub/gossipsub-v1.1.md
+++ b/pubsub/gossipsub/gossipsub-v1.1.md
@@ -642,7 +642,7 @@ should
 - The bootstrappers should be configured without a mesh (ie set `D=Dlo=Dhi=Dout=0`)
   and with Peer Exchange enabled, utilizing Signed Peer Records.
 - The application should assign a high application-specific score to the bootstrappers and
-  set the `AcceptPXThreshold` to a high enough value attainable only by the bootstrappers.
+  set `AcceptPXThreshold` to a high enough value attainable only by the bootstrappers.
 
 In this manner, the bootstrappers act purely as gossip and peer exchange nodes that facilitate
 the formation and maintenance of the network.

--- a/pubsub/gossipsub/gossipsub-v1.1.md
+++ b/pubsub/gossipsub/gossipsub-v1.1.md
@@ -638,7 +638,7 @@ purely through a small set of network entry points (bootstrappers) by utilizing 
 
 In order to successfully bootstrap the network without a discovery service, network operators
 should
-- Create and operate a set of bootstrapper nodes, that are known within client software.
+- Create and operate a set of stable bootstrapper nodes, whose addresses are known ahead of time by the application.
 - The bootstrappers should be configured without a mesh (ie set `D=Dlo=Dhi=Dout=0`)
   and with Peer Exchange enabled, utilizing Signed Peer Records.
 - Client software should assign a high application specific score to the bootstrappers and


### PR DESCRIPTION
The basic premise is bootstrapper PX instead of peer discovery services.