### PR TITLE
chore: update gossipsub js impl info

### DIFF
--- a/pubsub/gossipsub/README.md
+++ b/pubsub/gossipsub/README.md
@@ -21,7 +21,7 @@ Legend: ✅ = complete, 🏗 = in progress, ❕ = not started yet
 | Name                                                                                             | v1.0  | v1.1  |
 |--------------------------------------------------------------------------------------------------|:-----:|:-----:|
 | [go-libp2p-pubsub (Golang)](https://github.com/libp2p/go-libp2p-pubsub/blob/master/gossipsub.go) |   ✅  |   ✅  |
-| [gossipsub-js (JavaScript)](https://github.com/ChainSafeSystems/gossipsub-js)                    |   ✅  |   ❕  |
+| [js-libp2p-gossipsub (JavaScript)](https://github.com/ChainSafe/js-libp2p-gossipsub)                    |   ✅  |   🏗  |
 | [rust-libp2p (Rust)](https://github.com/libp2p/rust-libp2p/tree/master/protocols/gossipsub)      |   🏗  |   ❕  |
 | [py-libp2p (Python)](https://github.com/libp2p/py-libp2p/tree/master/libp2p/pubsub)              |   ✅  |   ❕  |
 | [jvm-libp2p (Java/Kotlin)](https://github.com/libp2p/jvm-libp2p/tree/develop/src/main/kotlin/io/libp2p/pubsub) |   ✅  |   ❕  


### PR DESCRIPTION
Gossipsub repo url changed from `ChainSafe/gossipsub-js` to `ChainSafe/js-libp2p-gossipsub`
Also gossipsub v1.1 implementation is in progress