### PR TITLE
Update gossipsub v1.1 spec with recommendation for secure bootstrapping

### DIFF
--- a/pubsub/gossipsub/gossipsub-v1.1.md
+++ b/pubsub/gossipsub/gossipsub-v1.1.md
@@ -2,7 +2,7 @@
 
 | Lifecycle Stage | Maturity       | Status | Latest Revision |
 |-----------------|----------------|--------|-----------------|
-| 1A              | Draft          | Active | r6, 2020-05-21  |
+| 1A              | Draft          | Active | r7, 2020-05-30  |
 
 
 Authors: [@vyzo]

--- a/pubsub/gossipsub/gossipsub-v1.1.md
+++ b/pubsub/gossipsub/gossipsub-v1.1.md
@@ -652,3 +652,12 @@ not receive PX or are advertised to the rest of the network.
 In addition, network operators may configure the application-specific scoring function such
 that the bootstrappers enforce further constraints into accepting new nodes (eg protocol
 handshakes, staked participation, and so on).
+
+It should be emphasized that the security of the peer discovery service affects the ability
+of the system to bootstrap securely and recover from large-scale attacks.
+Network operators must take care to ensure that whichever peer discovery mechanism they opt
+to utilize is resilient to attacks and can always return some honest peers so that connections
+between honest peers can be established.
+Furthermore, it is strongly recommended that any external discovery service is augmented by
+bootstrappers/directory nodes configured with Peer Exchange and high application specific scores,
+as outlined above.


### PR DESCRIPTION
Adds a paragraph in the recommendation for network operators to emphasize the necessity of secure peer discovery.