### PR TITLE
Update PubSub with nim-libp2p implementations

### DIFF
--- a/pubsub/README.md
+++ b/pubsub/README.md
@@ -67,8 +67,10 @@ You can find information about the PubSub research and notes in the following re
   - [libp2p/go-libp2p-pubsub/floodsub.go](https://github.com/libp2p/go-libp2p-pubsub/blob/master/floodsub.go);
   - [libp2p/js-libp2p-floodsub](http://github.com/libp2p/js-libp2p-floodsub);
   - [libp2p/rust-libp2p/floodsub](https://github.com/libp2p/rust-libp2p/tree/master/protocols/floodsub)
+  - [status-im/nim-libp2p/floodsub](https://github.com/status-im/nim-libp2p/blob/master/libp2p/protocols/pubsub/floodsub.nim)
 - GossipSub, extensible baseline pubsub (2018)
   - [gossipsub](https://github.com/libp2p/specs/tree/master/pubsub/gossipsub#implementation-status)
+  - [status-im/nim-libp2p/gossipsub](https://github.com/status-im/nim-libp2p/blob/master/libp2p/protocols/pubsub/gossipsub.nim)
 - [EpiSub](https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/episub.md), an epidemic broadcast tree router (defined 2018, not yet started as of Oct 2018)
 
 ## The RPC

--- a/pubsub/README.md
+++ b/pubsub/README.md
@@ -70,7 +70,6 @@ You can find information about the PubSub research and notes in the following re
   - [status-im/nim-libp2p/floodsub](https://github.com/status-im/nim-libp2p/blob/master/libp2p/protocols/pubsub/floodsub.nim)
 - GossipSub, extensible baseline pubsub (2018)
   - [gossipsub](https://github.com/libp2p/specs/tree/master/pubsub/gossipsub#implementation-status)
-  - [status-im/nim-libp2p/gossipsub](https://github.com/status-im/nim-libp2p/blob/master/libp2p/protocols/pubsub/gossipsub.nim)
 - [EpiSub](https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/episub.md), an epidemic broadcast tree router (defined 2018, not yet started as of Oct 2018)
 
 ## The RPC

--- a/pubsub/gossipsub/README.md
+++ b/pubsub/gossipsub/README.md
@@ -28,7 +28,8 @@ Legend: ✅ = complete, 🏗 = in progress, ❕ = not started yet
 | [js-libp2p-gossipsub (JavaScript)](https://github.com/ChainSafe/js-libp2p-gossipsub)                    |   ✅  |   🏗  |
 | [rust-libp2p (Rust)](https://github.com/libp2p/rust-libp2p/tree/master/protocols/gossipsub)      |   🏗  |   ❕  |
 | [py-libp2p (Python)](https://github.com/libp2p/py-libp2p/tree/master/libp2p/pubsub)              |   ✅  |   ❕  |
-| [jvm-libp2p (Java/Kotlin)](https://github.com/libp2p/jvm-libp2p/tree/develop/src/main/kotlin/io/libp2p/pubsub) |   ✅  |   ❕  
+| [jvm-libp2p (Java/Kotlin)](https://github.com/libp2p/jvm-libp2p/tree/develop/src/main/kotlin/io/libp2p/pubsub) |   ✅  |   ❕  |
+| [nim-libp2p (Nim)](https://github.com/status-im/nim-libp2p/blob/master/libp2p/protocols/pubsub/gossipsub.nim) |   ✅  |   🏗  |
 
 Additional tooling:
 


### PR DESCRIPTION
I noticed there was a room in the PubSub specs for implementation, but a lot of implementations (see Eth2) seems to be missing. Added nim-libp2p as that's the one I'm currently using :)