### PR TITLE
PubSub: Remove second-guessing naming of Message field

### DIFF
--- a/pubsub/README.md
+++ b/pubsub/README.md
@@ -99,8 +99,7 @@ false signifies 'unsubscribe'.
 
 ## The Message
 
-The RPC message can contain zero or more messages of type 'Message' (perhaps
-this should be named better?). The Message protobuf looks like this:
+The RPC message can contain zero or more messages of type 'Message'. The Message protobuf looks like this:
 
 ```protobuf
 message Message {


### PR DESCRIPTION
Small tweak, but it kept jumping out at me as I'm reading the spec. A spec should be written in an authoritative manner and not second-guess itself. Right now it reads more like a note to self that was left over.

If this is a possible enhancement/renaming, it should be captured in a separate issue IMO.

It is also unlikely that this field will change, considering how many clients implemented it with this naming.

Finally, I personally think the name is perfectly fine :)