### PR TITLE
fix: rendezvous spec

### DIFF
--- a/rendezvous/README.md
+++ b/rendezvous/README.md
@@ -77,7 +77,7 @@ discovery within application specific namespaces. Peers connect to the
 rendezvous point and register their presence in one or more
 namespaces. It is not allowed to register arbitrary peers in a
 namespace; only the peer initiating the registration can register
-itself. The register message contains a serialized [signed peer record]()
+itself. The register message contains a serialized [signed peer record](https://github.com/libp2p/specs/blob/377f05a/RFC/0002-signed-envelopes.md)
 created by the peer, which can be validated by others.
 
 Peers registered with the rendezvous point can be discovered by other

--- a/rendezvous/README.md
+++ b/rendezvous/README.md
@@ -14,6 +14,7 @@ Interest Group: [@daviddias], [@whyrusleeping], [@Stebalien], [@jacobheun], [@yu
 [@Stebalien]: https://github.com/Stebalien
 [@jacobheun]: https://github.com/jacobheun
 [@yusefnapora]: https://github.com/yusefnapora
+[@vasco-santos]: https://github.com/vasco-santos
 
 See the [lifecycle document][lifecycle-spec] for context about maturity level
 and spec status.
@@ -69,7 +70,6 @@ number of rendezvous points can federate using pubsub for internal
 real-time distribution, while still providing a simple interface to
 clients.
 
-
 ## The Protocol
 
 The rendezvous protocol provides facilities for real-time peer
@@ -77,7 +77,8 @@ discovery within application specific namespaces. Peers connect to the
 rendezvous point and register their presence in one or more
 namespaces. It is not allowed to register arbitrary peers in a
 namespace; only the peer initiating the registration can register
-itself.
+itself. The register message contains a serialized [signed peer record]()
+created by the peer, which can be validated by others.
 
 Peers registered with the rendezvous point can be discovered by other
 nodes by querying the rendezvous point. The query specifies the
@@ -195,16 +196,10 @@ message Message {
     E_UNAVAILABLE       = 400;
   }
 
-  message PeerInfo {
-    optional bytes id = 1;
-    repeated bytes addrs = 2;
-  }
-
   message Register {
     optional string ns = 1;
-    optional PeerInfo peer = 2;
+    optional bytes signedPeerRecord = 2;
     optional int64 ttl = 3; // in seconds
-    optional bytes signedPeerRecord = 4;
   }
 
   message RegisterResponse {

--- a/rendezvous/README.md
+++ b/rendezvous/README.md
@@ -6,7 +6,7 @@
 
 Authors: [@vyzo]
 
-Interest Group: [@daviddias], [@whyrusleeping], [@Stebalien], [@jacobheun], [@yusefnapora]
+Interest Group: [@daviddias], [@whyrusleeping], [@Stebalien], [@jacobheun], [@yusefnapora], [@vasco-santos]
 
 [@vyzo]: https://github.com/vyzo
 [@daviddias]: https://github.com/daviddias
@@ -204,6 +204,7 @@ message Message {
     optional string ns = 1;
     optional PeerInfo peer = 2;
     optional int64 ttl = 3; // in seconds
+    optional bytes signedPeerRecord = 4;
   }
 
   message RegisterResponse {


### PR DESCRIPTION
This PR adds the SignedPeerRecord to the Register message.

Since this is still a Working Draft spec, there are a few things that I would like to suggest:

- I think we should drop the `PeerInfo` message and just use the `SignedPeerRecord`
- Should we add a limit in the size of a namespace to register?