### PR TITLE
Make messageIDs bytes instead of strings

### DIFF
--- a/pubsub/gossipsub/gossipsub-v1.0.md
+++ b/pubsub/gossipsub/gossipsub-v1.0.md
@@ -520,11 +520,11 @@ message ControlMessage {
 
 message ControlIHave {
 	optional string topicID = 1;
-	repeated string messageIDs = 2;
+	repeated bytes messageIDs = 2;
 }
 
 message ControlIWant {
-	repeated string messageIDs = 1;
+	repeated bytes messageIDs = 1;
 }
 
 message ControlGraft {


### PR DESCRIPTION
Rationale:
- go-libp2p currently produces non-utf8 strings
- making this bytes allows more flexibility in creating message ids, e.g.
  - random bytes
  - hashes

This issue was discovered in https://github.com/libp2p/rust-libp2p/issues/1671 . There is a coresponding issue in go-ipfs-pubsub, https://github.com/libp2p/go-libp2p-pubsub/issues/361

Changing this should have no negative impact. Implementations that expect valid utf-8 strings are already broken, because go-ipfs emits non utf8 strings. See https://github.com/libp2p/go-libp2p-pubsub/issues/361#issuecomment-663569492