### PR TITLE
fix(noise): correct the maturity label to match the lifecycle stage

### DIFF
--- a/noise/README.md
+++ b/noise/README.md
@@ -3,9 +3,9 @@
 > A libp2p transport secure channel handshake built with the Noise Protocol
 > Framework.
 
-| Lifecycle Stage | Maturity      | Status | Latest Revision |
-|-----------------|---------------|--------|-----------------|
-| 3A              | Working Draft | Active | r2, 2020-03-30  |
+| Lifecycle Stage | Maturity       | Status | Latest Revision |
+|-----------------|----------------|--------|-----------------|
+| 3A              | Recommendation | Active | r2, 2020-03-30  |
 
 Authors: [@yusefnapora]
 


### PR DESCRIPTION
This just corrects the maturity label, it should be `Recommendation` per the lifecycle change to 3A via https://github.com/libp2p/specs/pull/263.