### PR TITLE
gossipsub: add eth2 developers to interest group.

### DIFF
--- a/pubsub/gossipsub/gossipsub-v1.1.md
+++ b/pubsub/gossipsub/gossipsub-v1.1.md
@@ -6,7 +6,7 @@
 
 Authors: [@vyzo]
 
-Interest Group: [@yusefnapora], [@raulk], [@whyrusleeping], [@Stebalien], [@daviddias]
+Interest Group: [@yusefnapora], [@raulk], [@whyrusleeping], [@Stebalien], [@daviddias], [@protolambda], [@djrtwo], [@dryajov], [@mpetrunic], [@AgeManning], [@Nashatyrev], [@mhchia]
 
 [@whyrusleeping]: https://github.com/whyrusleeping
 [@yusefnapora]: https://github.com/yusefnapora
@@ -14,6 +14,13 @@ Interest Group: [@yusefnapora], [@raulk], [@whyrusleeping], [@Stebalien], [@davi
 [@vyzo]: https://github.com/vyzo
 [@Stebalien]: https://github.com/Stebalien
 [@daviddias]: https://github.com/daviddias
+[@protolambda]: https://github.com/protolambda
+[@djrtwo]: https://github.com/djrtwo
+[@dryajov]: https://github.com/dryajov
+[@mpetrunic]: https://github.com/mpetrunic
+[@AgeManning]: https://github.com/AgeManning
+[@Nashatyrev]: https://github.com/Nashatyrev
+[@mhchia]: https://github.com/mhchia
 
 See the [lifecycle document][lifecycle-spec] for context about maturity level and spec status.
 


### PR DESCRIPTION
Nominating gossipsub developers from other libp2p implementations that Eth2 uses to be notified of changes in the gossipsub spec: @protolambda, @djrtwo, @dryajov, @mpetrunic, @AgeManning, @Nashatyrev, @mhchia.