### PR TITLE
chore: update js gossipsub implementation status to complete

### DIFF
--- a/pubsub/gossipsub/README.md
+++ b/pubsub/gossipsub/README.md
@@ -25,7 +25,7 @@ Legend: ✅ = complete, 🏗 = in progress, ❕ = not started yet
 | Name                                                                                             | v1.0  | v1.1  |
 |--------------------------------------------------------------------------------------------------|:-----:|:-----:|
 | [go-libp2p-pubsub (Golang)](https://github.com/libp2p/go-libp2p-pubsub/blob/master/gossipsub.go) |   ✅  |   ✅  |
-| [js-libp2p-gossipsub (JavaScript)](https://github.com/ChainSafe/js-libp2p-gossipsub)                    |   ✅  |   🏗  |
+| [js-libp2p-gossipsub (JavaScript)](https://github.com/ChainSafe/js-libp2p-gossipsub)                    |   ✅  |   ✅  |
 | [rust-libp2p (Rust)](https://github.com/libp2p/rust-libp2p/tree/master/protocols/gossipsub)      |   🏗  |   🏗  |
 | [py-libp2p (Python)](https://github.com/libp2p/py-libp2p/tree/master/libp2p/pubsub)              |   ✅  |   🏗  |
 | [jvm-libp2p (Java/Kotlin)](https://github.com/libp2p/jvm-libp2p/tree/develop/src/main/kotlin/io/libp2p/pubsub) |   ✅  |   🏗  |


### PR DESCRIPTION
[js-libp2p-gossipsub](https://github.com/ChainSafe/js-libp2p-gossipsub) had Gossipsub1.1 released in `libp2p-gossipsub@0.6.0` and is supported from `libp2p@0.29.x` is JS 🎉 