### PR TITLE
gossipsub v1.1: introduce message signing policy

### DIFF
--- a/pubsub/README.md
+++ b/pubsub/README.md
@@ -171,7 +171,7 @@ It was also proposed in [#116](https://github.com/libp2p/specs/issues/116)
 to use a `message_hash`, however, it was noted:
 > a potential caveat with using hashes instead of seqnos:
 the peer won't be able to send identical messages (e.g. keepalives) within the
-timecache interval, as they will get rejected as duplicates.
+timecache interval, as they will get treated as duplicates.
 
 Some applications may not need keepalives, or choose to implement something more specific than a message hash. In those cases where duplicate payloads are not desirable, a `content-based` message ID function may be more appropriate.
 

--- a/pubsub/README.md
+++ b/pubsub/README.md
@@ -32,6 +32,7 @@ and spec status.
     - [The RPC](#the-rpc)
     - [The Message](#the-message)
     - [Message Signing](#message-signing)
+    - [Message Identification](#message-identification)
     - [The Topic Descriptor](#the-topic-descriptor)
         - [AuthOpts](#authopts)
             - [AuthMode 'NONE'](#authmode-none)
@@ -145,7 +146,7 @@ economics (see e.g.
 and
 [here](https://ethresear.ch/t/improving-the-ux-of-rent-with-a-sleeping-waking-mechanism/1480)).
 
-## Message identification
+## Message Identification
 
 To uniquely identify a message in a set of topics, a `message_id` is computed based on the message.
 This can be configured on the application layer, as `message_id_fn(*Message) => message_id`, 

--- a/pubsub/README.md
+++ b/pubsub/README.md
@@ -153,6 +153,10 @@ and
 
 Messages can be optionally signed, and it is up to the peer whether to accept and forward
 unsigned messages.
+When the receiver expects unsigned content-based messages, and thus does not expect
+the `from`, `seqno`, `signature`, or `key` fields, it may reject the messages (`StrictNoSign`).
+And if not, the receiver may choose to enforce signatures strictly (`StrictSign`).
+This optionality is configurable with the signing policy options starting from `v1.1`. 
 
 For signing purposes, the `signature` and `key` fields are used:
 - The `signature` field contains the signature.
@@ -160,6 +164,7 @@ For signing purposes, the `signature` and `key` fields are used:
   When present, it must match the peer ID.
 
 The signature is computed over the marshalled message protobuf _excluding_ the key field.
+This includes any fields that are not recognized, but still included in the marshalled data.
 The protobuf blob is prefixed by the string `libp2p-pubsub:` before signing.
 
 When signature validation fails for a signed message, the implementation must

--- a/pubsub/README.md
+++ b/pubsub/README.md
@@ -153,17 +153,18 @@ and
 
 Messages can be optionally signed, and it is up to the peer whether to accept and forward
 unsigned messages.
-When the receiver expects unsigned content-based messages, and thus does not expect
+The default choice of origin-stamped messaging, the receiver should enforce signatures strictly (`StrictSign`).
+When the receiver expects unsigned content-stamped messages, and thus does not expect
 the `from`, `seqno`, `signature`, or `key` fields, it may reject the messages (`StrictNoSign`).
-And if not, the receiver may choose to enforce signatures strictly (`StrictSign`).
-This optionality is configurable with the signing policy options starting from `v1.1`. 
+
+This optionality is configurable with the signature policy options starting from gossipsub v1.1. 
 
 For signing purposes, the `signature` and `key` fields are used:
 - The `signature` field contains the signature.
 - The `key` field contains the signing key when it cannot be inlined in the source peer ID.
   When present, it must match the peer ID.
 
-The signature is computed over the marshalled message protobuf _excluding_ the key field.
+The signature is computed over the marshalled message protobuf _excluding_ the `signature` field itself.
 This includes any fields that are not recognized, but still included in the marshalled data.
 The protobuf blob is prefixed by the string `libp2p-pubsub:` before signing.
 

--- a/pubsub/README.md
+++ b/pubsub/README.md
@@ -149,12 +149,16 @@ and
 ## Message Identification
 
 To uniquely identify a message in a set of topics, a `message_id` is computed based on the message.
-This can be configured on the application layer, as `message_id_fn(*Message) => message_id`, 
-which generally fits in two flavors:
-- **origin-stamped** messaging: the concatenation of the `seqno` and `from` fields
+This can be configured on the application layer, as `message_id_fn(*Message) => message_id`.
+A `message_id_fn` may conditionally call different `message_id_fn` implementations per topic (or group thereof).
+
+The message ID approach generally fits in two flavors:
+- **origin-stamped** messaging: the combination of the `seqno` and `from` fields
   uniquely identifies a message based on the *author*.
 - **content-stamped** messaging: a message ID derived from the `data` field
   uniquely identifies a message based on the *data*.
+
+The default `message_id_fn` is origin-stamped, and defined as the string concatenation of `from` and `seqno`.
 
 If fabricated collisions are not a concern, or difficult enough within the window the message is relevant in,
 a `message_id` based on a short digest of inputs may benefit performance.

--- a/pubsub/gossipsub/gossipsub-v1.1.md
+++ b/pubsub/gossipsub/gossipsub-v1.1.md
@@ -138,7 +138,7 @@ message PeerInfo {
 
 ### Signature Policy
 
-The usage of the `signature`, `key`, `from`, and `seqno` fields in `Message` is now configurable.
+The usage of the `signature`, `key`, `from`, and `seqno` fields in `Message` is now configurable per topic, in the manners specified in this section.
 > [[ Implementation note ]]: At the time of writing this section, go-libp2p-pubsub (reference implementation of this spec) allows for configuring the signature policy at a global pubsub instance level. This needs to be pushed down to topic-level configuration. Other implementations are encouraged to support topic-level configuration, as the spec mandates.
 
 In the default origin-stamped messaging, the fields need to be strictly enforced:

--- a/pubsub/gossipsub/gossipsub-v1.1.md
+++ b/pubsub/gossipsub/gossipsub-v1.1.md
@@ -37,6 +37,7 @@ See the [lifecycle document][lifecycle-spec] for context about maturity level an
   - [Explicit Peering Agreements](#explicit-peering-agreements)
   - [PRUNE Backoff and Peer Exchange](#prune-backoff-and-peer-exchange)
     - [Protobuf](#protobuf)
+  - [Signature policy](#signature-policy)
   - [Flood Publishing](#flood-publishing)
   - [Adaptive Gossip Dissemination](#adaptive-gossip-dissemination)
   - [Outbound Mesh Quotas](#outbound-mesh-quotas)
@@ -133,6 +134,29 @@ message PeerInfo {
 	optional bytes signedPeerRecord = 2;
 }
 ```
+
+### Signature policy
+
+The usage of the `signature`, `key`, `from`, and `seqno` fields in `Message` is now configurable.
+These fields may negatively affect privacy in content-addressed messaging,
+and may need to be strictly enforced in author-addressed messaging.
+
+In gossipsub v1.0, a "lax" signing policy is effective: verify signatures, and if not, only when present.
+In gossipsub v1.1, these fields are strictly present and verified, or completely omitted altogether.
+An implementation may choose to support the legacy v1.0 "lax" signing policy,
+ along with an explicit message authoring option. 
+
+Gossipsub v1.1 has two policies to choose from:
+- `StrictSign`:
+  - Produces the `signature`, `key` (`from` may be enough), `from` and `seqno` fields.
+  - Enforce the fields to be present, reject otherwise.
+  - Verify the signature, reject otherwise.
+  - Propagate the fields if valid.
+- `StrictNoSign`:
+  - Produces messages without the `signature`, `key`, `from` and `seqno` fields.
+    The corresponding protobuf key-value pairs are absent from the marshalled message, not just empty.
+  - Enforce the fields to be absent, reject otherwise.
+  - Propagate only if the fields are absent.
 
 ### Flood Publishing
 

--- a/pubsub/gossipsub/gossipsub-v1.1.md
+++ b/pubsub/gossipsub/gossipsub-v1.1.md
@@ -37,7 +37,8 @@ See the [lifecycle document][lifecycle-spec] for context about maturity level an
   - [Explicit Peering Agreements](#explicit-peering-agreements)
   - [PRUNE Backoff and Peer Exchange](#prune-backoff-and-peer-exchange)
     - [Protobuf](#protobuf)
-  - [Signature policy](#signature-policy)
+  - [Signature Policy](#signature-policy)
+    - [Signature Policy Options](#signature-policy-options)
   - [Flood Publishing](#flood-publishing)
   - [Adaptive Gossip Dissemination](#adaptive-gossip-dissemination)
   - [Outbound Mesh Quotas](#outbound-mesh-quotas)
@@ -135,7 +136,7 @@ message PeerInfo {
 }
 ```
 
-### Signature policy
+### Signature Policy
 
 The usage of the `signature`, `key`, `from`, and `seqno` fields in `Message` is now configurable.
 Initially this could be configured globally, however, configuration on a per-topic basis will facilitate mixed protocols better.
@@ -146,7 +147,7 @@ the `seqno` and `from` fields form the `message_id`, and should be verified to a
 In content-stamped messaging, the fields may negatively affect privacy:
 revealing the relationship between `data` and `from`/`seqno`.
 
-#### Signature policy options
+#### Signature Policy Options
 
 In gossipsub v1.1, these fields are strictly present and verified, or completely omitted altogether:
 - `StrictSign`:

--- a/pubsub/gossipsub/gossipsub-v1.1.md
+++ b/pubsub/gossipsub/gossipsub-v1.1.md
@@ -139,7 +139,7 @@ message PeerInfo {
 ### Signature Policy
 
 The usage of the `signature`, `key`, `from`, and `seqno` fields in `Message` is now configurable.
-Initially this could be configured globally, however, configuration on a per-topic basis will facilitate mixed protocols better.
+Initially this could be configured globally, however, because the policies are mutually incompatible, configuration on a per-topic basis will facilitate mixed protocols better.
 
 In the default origin-stamped messaging, the fields need to be strictly enforced:
 the `seqno` and `from` fields form the `message_id`, and should be verified to avoid `message_id` collisions.


### PR DESCRIPTION
See https://github.com/libp2p/go-libp2p-pubsub/pull/359 for motivation and related discussion.

In short: Eth2 uses content-addressing and does not use these fields. If not content-addressed, signature data should be verified more strictly.

Changes:
- Pubsub readme: 
  - Describe the optionality of singing in the relevant signing section of pubsub, and refer to new gossipsub v1.1 configuration option
  - Clarify that signatures are singing over all fields (incl unrecognized fields)
- Gossipsub v1.1:
  - Briefly describe the general two cases when the fields are desired or not.
  - Document legacy "lax" behavior may be implemented as additional signing policies
  - Document two main (strict) signing policies
    - Feedback wanted: best way to describe the rejection of messages with bad signature or unexpected/missing fields?

Out of scope:
- We had a related discussion about rejecting unrecognized protobuf fields altogether, to avoid any unexpected privacy issues or encoding edge cases. (will open an issue for this)

See https://github.com/ethereum/eth2.0-specs/issues/1981 for Eth2 progress on this work, and clients implementing this functionality in gossipsub implementations.

PS. This is my first contribution directly to the libp2p specs, let me know if you have feedback to details such as formatting, I am happy to make changes.

cc @raulk, implemented the spec changes, review/edits welcome.