### PR TITLE
Typo fix.

### DIFF
--- a/connections/README.md
+++ b/connections/README.md
@@ -401,6 +401,6 @@ updated to incorporate the changes.
 [js-peer-book]: https://github.com/libp2p/js-peer-book
 [quic-spec]: https://datatracker.ietf.org/doc/draft-ietf-quic-transport/
 [mss-2-pr]: https://github.com/libp2p/specs/pull/95
-[go-eventbus]: https://gihub.com/libp2p/go-eventbus
+[go-eventbus]: https://github.com/libp2p/go-eventbus
 [go-net-notifee]: https://github.com/libp2p/go-libp2p-core/blob/master/network/notifee.go
 [identify/push]: ../identify/README.md#identify-push


### PR DESCRIPTION
Fix typo in hyper-link.