### PR TITLE
secio: Transition SECIO spec from Active to Deprecated

### DIFF
--- a/secio/README.md
+++ b/secio/README.md
@@ -3,9 +3,12 @@
 > A stream security transport for libp2p. Streams wrapped by SECIO use secure
 > sessions to encrypt all traffic.
 
-| Lifecycle Stage | Maturity Level | Status | Latest Revision |
-|-----------------|----------------|--------|-----------------|
-| 3A              | Recommendation | Active | r0, 2019-05-27  |
+> SECIO is deprecated and we advise against using it. See [this blog
+> post](https://blog.ipfs.io/2020-08-07-deprecating-secio/) for details.
+
+| Lifecycle Stage | Maturity Level | Status     | Latest Revision |
+|-----------------|----------------|------------|-----------------|
+| 3D              | Recommendation | Deprecated | r1, 2021-03-26  |
 
 Authors: [@jbenet], [@bigs], [@yusefnapora]
 


### PR DESCRIPTION
The SECIO security transport has been deprecated [1]. This commit
updates the specification accordingly.

> The transition from the `Active` status to the `Deprecated` status is
performed via a *Pull Request* that is reviewed by the _Interest Group_,
allowing 5 working days to elapse to collect feedback from the libp2p
community at large.

As per the specification life cycle specification I am requesting a review
from @Stebalien, @richardschneider, @tomaka and @raulk.


[1] https://blog.ipfs.io/2020-08-07-deprecating-secio/