### PR TITLE
Revert "mplex: allow for 28bit stream IDs."

### DIFF
--- a/mplex/README.md
+++ b/mplex/README.md
@@ -62,7 +62,7 @@ flag = header & 0x07
 id = header >> 3
 ```
 
-The maximum header length is 9 bytes (per the unsigned-varint spec). With 9 continuation bits and 3 message flag bits  the maximum stream ID is 60 bits (maximum value of `2^60 - 1`).
+The maximum header length is 9 bytes (per the unsigned-varint spec). With 9 continuation bits and 3 message flag bits the maximum stream ID is 60 bits (maximum value of `2^60 - 1`).
 
 ### Flag Values
 

--- a/mplex/README.md
+++ b/mplex/README.md
@@ -62,8 +62,7 @@ flag = header & 0x07
 id = header >> 3
 ```
 
-- Implementations MUST support up to 28bit stream IDs (32bit headers pre-encoding, 5 bytes after varint encoding).
-- Implementations SHOULD support up to 60bit stream IDs (64bit headers pre-encoding, 9 bytes after varint encoding).
+The maximum header length is 9 bytes (per the unsigned-varint spec). With 9 continuation bits and 3 message flag bits  the maximum stream ID is 60 bits (maximum value of `2^60 - 1`).
 
 ### Flag Values
 


### PR DESCRIPTION
This reverts commit 51ec3e5ab16858c7d2e9b9bfb15074aba886c8f0.

See the discussion starting at:

https://github.com/libp2p/specs/pull/317#issuecomment-826362668