### PR TITLE
identify: Document identify behavior for asymetrical protocols

### DIFF
--- a/identify/README.md
+++ b/identify/README.md
@@ -120,3 +120,9 @@ observable source address.
 ### protocols
 
 This is a list of protocols supported by the peer.
+
+Note on asymmetrical protocols: Assume an asymmetrical request-response style
+protocol `foo` where some clients only support initiating requests while some
+servers (only) support responding to requests. To prevent clients from
+initiating requests to other clients, which given them being clients they fail
+to respond, clients should not list `foo` in their `protocols` list.

--- a/identify/README.md
+++ b/identify/README.md
@@ -121,8 +121,10 @@ observable source address.
 
 This is a list of protocols supported by the peer.
 
-Note on asymmetrical protocols: Assume an asymmetrical request-response style
-protocol `foo` where some clients only support initiating requests while some
-servers (only) support responding to requests. To prevent clients from
-initiating requests to other clients, which given them being clients they fail
-to respond, clients should not list `foo` in their `protocols` list.
+A node should only advertise a protocol if it's willing to receive inbound
+streams on that protocol. This is relevant for asymmetrical protocols. For
+example assume an asymmetrical request-response style protocol `foo` where some
+clients only support initiating requests while some servers (only) support
+responding to requests. To prevent clients from initiating requests to other
+clients, which given them being clients they fail to respond, clients should not
+advertise `foo` in their `protocols` list.


### PR DESCRIPTION
> Note on asymmetrical protocols: Assume an asymmetrical
request-response style protocol `foo` where some clients only support
initiating requests while some servers (only) support responding to
requests. To prevent clients from initiating requests to other clients,
which given them being clients they fail to respond, clients should not
list `foo` in their `protocols` list.

Question emerged in https://github.com/libp2p/specs/issues/324.