### PR TITLE
[Rendezvous] Draft proof-of-work requirement

### DIFF
--- a/rendezvous/README.md
+++ b/rendezvous/README.md
@@ -284,7 +284,7 @@ message Message {
   }
   
   message ProofOfWork {
-    repeated bytes hash = 1;
+    optional bytes hash = 1;
     optional int64 nonce = 2;
   }
 

--- a/rendezvous/README.md
+++ b/rendezvous/README.md
@@ -294,6 +294,7 @@ message Message {
   optional Unregister unregister = 4;
   optional Discover discover = 5;
   optional DiscoverResponse discoverResponse = 6;
+  optional ProofOfWork proofOfWork = 7;
 }
 ```
 


### PR DESCRIPTION
This is a draft for the proof of work requirement that is to be defined in the rendezvous protocol.

I've considered a number of designs and ended up with what is presented here. I am not sure how much people will like the additional messages but it solves an important problem: The PoW must be unique to a single registration and the best way to achieve that IMO is for the rendezvous point to hand out a challenge to the client. Given that `REGISTER` is sent by the client, there isn't really any opportunity before the register response to send back a challenge which is why I opted to introduce a dedicated status code that requests proof of work from the client.

The main consequence of this is that it allows rendezvous points to not require proof of work for the first few registrations for example or whilst they are under low load. I am not sure we need this flexibility but it is there with the current design.

If however we want proof of work with every registration anyway, then the additional message is a bit of a waste and it would be ideal if the client could just include the proof of work with the original `REGISTER` message. Unfortunately, I could come up with a way of making the PoW unique to this registration. `ttl` is a relative value and therefore, a PoW that is calculated once could be reused over and over again at a later point in time.