### PR TITLE
*: Update Kademlia and Circuit Relay v2 links

### DIFF
--- a/RFC/0003-routing-records.md
+++ b/RFC/0003-routing-records.md
@@ -283,4 +283,4 @@ before interacting with them directly. This could be added as a new field in the
 [autonat]: https://github.com/libp2p/specs/issues/180
 [envelope-rfc]: ./0002-signed-envelopes.md
 [eip-778]: https://eips.ethereum.org/EIPS/eip-778
-[dht-spec]: https://github.com/libp2p/specs/pull/108/
+[dht-spec]: https://github.com/libp2p/specs/blob/master/kad-dht/README.md

--- a/connections/hole-punching.md
+++ b/connections/hole-punching.md
@@ -284,6 +284,6 @@ stack, thus not allowing _insecure_ connections from [secure contexts].
 [project-flare]: https://github.com/protocol/web3-dev-team/pull/21
 [symmetric-nat]: https://dh2i.com/kbs/kbs-2961448-understanding-different-nat-types-and-hole-punching/
 [ipfs-kademlia]: https://docs.ipfs.io/concepts/dht/
-[Kademlia]: https://github.com/libp2p/specs/pull/108/
+[Kademlia]: https://github.com/libp2p/specs/blob/master/kad-dht/README.md
 [Gossipsub]: ../pubsub/gossipsub/README.md
 [secure contexts]: https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts

--- a/connections/hole-punching.md
+++ b/connections/hole-punching.md
@@ -278,8 +278,8 @@ stack, thus not allowing _insecure_ connections from [secure contexts].
 [AutoNAT]: https://github.com/libp2p/specs/issues/180
 [Identify]: ../identify/README.md
 [SDP]: https://en.wikipedia.org/wiki/Session_Description_Protocol
-[circuit-relay-v1]: https://github.com/libp2p/specs/tree/master/relay
-[circuit-relay-v2]: https://github.com/libp2p/specs/issues/314
+[circuit-relay-v1]: https://github.com/libp2p/specs/blob/master/relay/circuit-v1.md
+[circuit-relay-v2]: https://github.com/libp2p/specs/blob/master/relay/circuit-v2.md
 [DCUTR]: https://github.com/libp2p/specs/pull/173
 [project-flare]: https://github.com/protocol/web3-dev-team/pull/21
 [symmetric-nat]: https://dh2i.com/kbs/kbs-2961448-understanding-different-nat-types-and-hole-punching/


### PR DESCRIPTION
With https://github.com/libp2p/specs/pull/108/ and https://github.com/libp2p/specs/pull/325 merged, we can reference the specifications directly, instead of their initial pull requests.