### PR TITLE
[Rendezvous] Clarify `UNREGISTER` behaviour and remove `id` field

### DIFF
--- a/rendezvous/README.md
+++ b/rendezvous/README.md
@@ -122,7 +122,9 @@ an `E_INVALID_TTL` status.
 Peers can refresh their registrations at any time with a new
 `REGISTER` message; the TTL of the new message supersedes previous
 registrations. Peers can also cancel existing registrations at any
-time with an explicit `UNREGISTER` message.
+time with an explicit `UNREGISTER` message. An `UNREGISTER` message does
+**not** have an explicit response. `UNREGISTER` messages for a namespace
+that a client is currently not registered for should be treated as a no-op.
 
 The registration response includes the actual TTL of the registration,
 so that peers know when to refresh.

--- a/rendezvous/README.md
+++ b/rendezvous/README.md
@@ -2,7 +2,7 @@
 
 | Lifecycle Stage | Maturity      | Status | Latest Revision |
 |-----------------|---------------|--------|-----------------|
-| 1A              | Working Draft | Active | r2, 2021-06-24  |
+| 1A              | Working Draft | Active | r3, 2021-07-12  |
 
 Authors: [@vyzo]
 

--- a/rendezvous/README.md
+++ b/rendezvous/README.md
@@ -225,7 +225,7 @@ message Message {
 
   message Unregister {
     optional string ns = 1;
-    optional bytes id = 2;
+    // optional bytes id = 2; deprecated as per https://github.com/libp2p/specs/issues/335
   }
 
   message Discover {


### PR DESCRIPTION
All connections in libp2p are authenticated. As such, we don't have
to include the PeerId in the `Unregister` message. We only allow
peers to unregister themselves and therefore, this `id` would always
be equal to the one we are learn from the authentication layer. Having
to compare those and ensure they are equal is an unnecessary error
path.

This also clarifies the absence of an `UNREGISTER` response.

Resolves #335.