### PR TITLE
Clarify properties of the libp2p-noise handshake's second message

### DIFF
--- a/noise/README.md
+++ b/noise/README.md
@@ -218,9 +218,10 @@ These payloads MUST be inserted into the first message of the handshake pattern
 **that guarantees secrecy**. In practice, this means that the initiator must not
 send a payload in their first message. Instead, the initiator will send its
 payload in message 3 (closing message), whereas the responder will send theirs
-in message 2 (their only message). It should be stressed, that the second message of the handshake pattern has forward
-secrecy, however the sender has not authenticated the responder, so this payload might be sent to any
-party, including an active attacker.
+in message 2 (their only message). It should be stressed, that the second
+message of the handshake pattern has forward secrecy, however the sender has not
+authenticated the responder, so this payload might be sent to any party,
+including an active attacker.
 
 When decrypted, the payload contains a serialized [protobuf][protobuf]
 `NoiseHandshakePayload` message with the following schema:

--- a/noise/README.md
+++ b/noise/README.md
@@ -218,7 +218,9 @@ These payloads MUST be inserted into the first message of the handshake pattern
 **that guarantees secrecy**. In practice, this means that the initiator must not
 send a payload in their first message. Instead, the initiator will send its
 payload in message 3 (closing message), whereas the responder will send theirs
-in message 2 (their only message).
+in message 2 (their only message). It should be stressed, that the second message of the handshake pattern has forward
+secrecy, however the sender has not authenticated the responder, so this payload might be sent to any
+party, including an active attacker.
 
 When decrypted, the payload contains a serialized [protobuf][protobuf]
 `NoiseHandshakePayload` message with the following schema:


### PR DESCRIPTION
The libp2p-noise specification states the following related to early data (payloads): 
```
These payloads MUST be inserted into the first message of the handshake pattern that guarantees secrecy.
In practice, this means that the initiator must not send a payload in their first message.
Instead, the initiator will send its payload in message 3 (closing message),
whereas the responder will send theirs in message 2 (their only message)
```

According to Noise XX security properties, the second message with payload provides forward
secrecy, however, the sender has not authenticated the responder, so this payload might be sent to any
party, including an active attacker. So an active attacker can just establish a connection with the
responder host and get the early data. 

So, this MR just clarifies this moment.