### PR TITLE
Fix tls.md

### DIFF
--- a/tls/tls.md
+++ b/tls/tls.md
@@ -80,8 +80,8 @@ The public host key and the signature are ANS.1-encoded into the SignedKey data 
 
 ```asn1
 SignedKey ::= SEQUENCE {
-  publicKey BIT STRING,
-  signature BIT STRING 
+  publicKey OCTET STRING,
+  signature OCTET STRING 
 }
 ```
 


### PR DESCRIPTION
The go implementation uses `OCTET STRING` instead of `BIT STRING` for elements of `SignedKey`.

The options are:

1) fix the go implementation
2) update the specs

However with 1) we should also notify every implementors to fix it, e.g. https://github.com/alanshaw/js-libp2p-quic/blob/1f3c1dd6dff3c2e94710a1ae76e815e0805c8a99/src/crypto.js#L44