### PR TITLE
Define precisely how to marshal SubjectPublicKeyInfo structure in tls.md

### DIFF
--- a/tls/tls.md
+++ b/tls/tls.md
@@ -74,7 +74,7 @@ In order to prove ownership of its host key, an endpoint sends two values:
 
 The public host key allows the peer to calculate the peer ID of the peer it is connecting to. Clients MUST verify that the peer ID derived from the certificate matches the peer ID they intended to connect to, and MUST abort the connection if there is a mismatch.
 
-The peer signs the concatenation of the string `libp2p-tls-handshake:` and the public key that it used to generate the certificate carrying the libp2p Public Key Extension, using its private host key. The encoded public key is a `SubjectPublicKeyInfo` structure (see RFC 5280, Section 4.1):
+The peer signs the concatenation of the string `libp2p-tls-handshake:` and the encoded public key that it used to generate the certificate carrying the libp2p Public Key Extension, using its private host key. The public key is encoded as a `SubjectPublicKeyInfo` structure (see RFC 5280, Section 4.1):
 
 ```asn1
 SubjectPublicKeyInfo ::= SEQUENCE {

--- a/tls/tls.md
+++ b/tls/tls.md
@@ -74,7 +74,20 @@ In order to prove ownership of its host key, an endpoint sends two values:
 
 The public host key allows the peer to calculate the peer ID of the peer it is connecting to. Clients MUST verify that the peer ID derived from the certificate matches the peer ID they intended to connect to, and MUST abort the connection if there is a mismatch.
 
-The peer signs the concatenation of the string `libp2p-tls-handshake:` and the public key that it used to generate the certificate carrying the libp2p Public Key Extension, using its private host key. This signature provides cryptographic proof that the peer was in possession of the private host key at the time the certificate was signed. Peers MUST verify the signature, and abort the connection attempt if signature verification fails.
+The peer signs the concatenation of the string `libp2p-tls-handshake:` and the public key that it used to generate the certificate carrying the libp2p Public Key Extension, using its private host key. The encoded public key is a `SubjectPublicKeyInfo` structure (see RFC 5280, Section 4.1):
+
+```asn1
+SubjectPublicKeyInfo ::= SEQUENCE {
+  algorithm             AlgorithmIdentifier,
+  subject_public_key    BIT STRING
+}
+AlgorithmIdentifier  ::= SEQUENCE {
+  algorithm             OBJECT IDENTIFIER,
+  parameters            ANY DEFINED BY algorithm OPTIONAL
+}
+```
+
+This signature provides cryptographic proof that the peer was in possession of the private host key at the time the certificate was signed. Peers MUST verify the signature, and abort the connection attempt if signature verification fails.
 
 The public host key and the signature are ANS.1-encoded into the SignedKey data structure, which is carried in the libp2p Public Key Extension. The libp2p Public Key Extension is a X.509 extension with the Object Identier `1.3.6.1.4.1.53594.1.1`, [allocated by IANA to the libp2p project at Protocol Labs](https://www.iana.org/assignments/enterprise-numbers/enterprise-numbers).
 

--- a/tls/tls.md
+++ b/tls/tls.md
@@ -74,7 +74,7 @@ In order to prove ownership of its host key, an endpoint sends two values:
 
 The public host key allows the peer to calculate the peer ID of the peer it is connecting to. Clients MUST verify that the peer ID derived from the certificate matches the peer ID they intended to connect to, and MUST abort the connection if there is a mismatch.
 
-The peer signs the concatenation of the string `libp2p-tls-handshake:` and the encoded public key that it used to generate the certificate carrying the libp2p Public Key Extension, using its private host key. The public key is encoded as a `SubjectPublicKeyInfo` structure (see RFC 5280, Section 4.1):
+The peer signs the concatenation of the string `libp2p-tls-handshake:` and the encoded public key that it used to generate the certificate carrying the libp2p Public Key Extension, using its private host key. The public key is encoded as a `SubjectPublicKeyInfo` structure as described in RFC 5280, Section 4.1:
 
 ```asn1
 SubjectPublicKeyInfo ::= SEQUENCE {


### PR DESCRIPTION
This is a clarification how to marshal SubjectPublicKeyInfo according to the go implementation (https://github.com/libp2p/go-libp2p-tls/blob/7530faa07acbfc0aa918c072c2cb35d3c8d5d859/crypto.go#L143 and https://pkg.go.dev/crypto/x509#MarshalPKIXPublicKey).