### PR TITLE
relay/DCUtR: Make message type field `required`

### DIFF
--- a/relay/DCUtR.md
+++ b/relay/DCUtR.md
@@ -2,7 +2,7 @@
 
 | Lifecycle Stage | Maturity      | Status | Latest Revision    |
 |-----------------|---------------|--------|--------------------|
-| 1A              | Working Draft | Active | r0, 2021-08-17     |
+| 1A              | Working Draft | Active | r1, 2021-11-20     |
 
 Authors: [@vyzo]
 
@@ -135,7 +135,7 @@ message HolePunch {
     SYNC = 300;
   }
 
-  optional Type type=1;
+  required Type type=1;
 
   repeated bytes ObsAddrs = 2;
 }


### PR DESCRIPTION
The `type` field of the DCUtR message definition should not be
`optional`, as a message without a `Type` is useless. Instead it should
be `required`.

See also circuit relay v2 specification using `required` for `type`.

```protobuf
message HopMessage {
  enum Type {
    RESERVE = 0;
    CONNECT = 1;
    STATUS = 2;
  }

  required Type type = 1;
```

```protobuf
message StopMessage {
  enum Type {
    CONNECT = 0;
    STATUS = 1;
  }

  required Type type = 1;
```

If I am not mistaken, none of the libp2p implementations have released a DCUtR implementation yet, thus we can still easily make this change. Correct @marten-seemann?