### PR TITLE
ROADMAP: Prioritize global connectivity over connection handshake

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,8 +20,8 @@ third-party ownership of data.
         - [📮 Offline message queue / postbox](#📮-offline-message-queue--postbox)
         - [🤖 libp2p as a WASM library](#🤖-libp2p-as-a-wasm-library)
     - [Evolve](#evolve)
-        - [🤝 Low latency, efficient connection handshake](#🤝-low-latency-efficient-connection-handshake)
         - [🕸 Unprecedented global connectivity](#🕸-unprecedented-global-connectivity)
+        - [🤝 Low latency, efficient connection handshake](#🤝-low-latency-efficient-connection-handshake)
         - [Peer Routing Records](#peer-routing-records)
         - [🗣️ Polite peering](#🗣️-polite-peering)
         - [🧱 Composable routing](#🧱-composable-routing)
@@ -221,28 +221,6 @@ model.
 
 This is the stuff pushing the existing libp2p stack forward.
 
-### 🤝 Low latency, efficient connection handshake
-
-**High priority for: IPFS**
-
-**What?** Establishing a connection and performing the initial handshake
-should be as cheap and fast as possible. Supporting things like
-*selective* stream opening, *preemption*, *speculative* negotiation,
-*upfront* negotiation, protocol table *pinning*, etc. may enable us to
-achieve lower latencies when establishing connections, and even the
-0-RTT holy grail in some cases. These features are being discussed in
-the *Protocol Select* protocol design.
-
-**Why?** Multistream 1.0 is chatty and naïve. Streams are essential to
-libp2p, and negotiating them is currently inefficient in a number of
-scenarios. Also, bootstrapping a multiplexed connection is currently
-guesswork (we test protocols one by one, incurring in significant
-ping-pong).
-
-**Links:**
-
-- [Protocol Select specification](https://github.com/libp2p/specs/pull/349)
-
 ### 🕸 Unprecedented global connectivity
 
 **What?** A DHT crawl measurements (Nov 22nd 2019) showed that out
@@ -268,6 +246,28 @@ rest of the system.
   vision](https://github.com/mxinden/specs/blob/hole-punching/connections/hole-punching.md).
 
 - [NAT traversal tracking issue](https://github.com/libp2p/specs/issues/312).
+
+### 🤝 Low latency, efficient connection handshake
+
+**High priority for: IPFS**
+
+**What?** Establishing a connection and performing the initial handshake
+should be as cheap and fast as possible. Supporting things like
+*selective* stream opening, *preemption*, *speculative* negotiation,
+*upfront* negotiation, protocol table *pinning*, etc. may enable us to
+achieve lower latencies when establishing connections, and even the
+0-RTT holy grail in some cases. These features are being discussed in
+the *Protocol Select* protocol design.
+
+**Why?** Multistream 1.0 is chatty and naïve. Streams are essential to
+libp2p, and negotiating them is currently inefficient in a number of
+scenarios. Also, bootstrapping a multiplexed connection is currently
+guesswork (we test protocols one by one, incurring in significant
+ping-pong).
+
+**Links:**
+
+- [Protocol Select specification](https://github.com/libp2p/specs/pull/349)
 
 ### Peer Routing Records
 


### PR DESCRIPTION
Over the past few months @marten-seemann and I have focused our engineering time on the "Unprecedented global connectivity" item through _Project Flare_. We have not yet started on "Low latency, efficient connection handshake" (aka. Protocol Select).

To make sure our roadmap reflects the above, this pull request swaps the two.