### PR TITLE
relay/circuit-v2: Mark Reservation::expire as required

### DIFF
--- a/relay/circuit-v2.md
+++ b/relay/circuit-v2.md
@@ -4,7 +4,7 @@ This is the version 2 of the libp2p Circuit Relay protocol.
 
 | Lifecycle Stage | Maturity       | Status | Latest Revision |
 |-----------------|----------------|--------|-----------------|
-| 1A              | DRAFT          | Active | r0, 2021-05-05  |
+| 1A              | DRAFT          | Active | r1, 2021-12-17  |
 
 Authors: [@vyzo]
 
@@ -398,7 +398,7 @@ message Peer {
 }
 
 message Reservation {
-  optional uint64 expire = 1; // Unix expiration time (UTC)
+  required uint64 expire = 1; // Unix expiration time (UTC)
   repeated bytes addrs = 2;   // relay addrs for reserving peer
   optional bytes voucher = 3; // reservation voucher
 }


### PR DESCRIPTION
The Go implementation of the circuit relay v2 implementation treats the
`Reservation::expire` field as `required`:

``` Golang
result := &Reservation{}
result.Expiration = time.Unix(int64(rsvp.GetExpire()), 0)
if result.Expiration.Before(time.Now()) {
	return nil, fmt.Errorf("received reservation with expiration date in the past: %s", result.Expiration)
}
```

https://github.com/libp2p/go-libp2p/blob/bfee9f593553b3cdaecc351f04b98aac78b8d8af/p2p/protocol/circuitv2/client/reservation.go#L88-L92

Where `rsvp.GetExpire` returns `0` when `Reservation::expire` is not set:

``` Golang
func (m *Reservation) GetExpire() uint64 {
	if m != nil && m.Expire != nil {
		return *m.Expire
	}
	return 0
}
```

https://github.com/libp2p/go-libp2p/blob/bfee9f593553b3cdaecc351f04b98aac78b8d8af/p2p/protocol/circuitv2/pb/circuit.pb.go#L414-L419

While inexplicable to me why Go treats the non-set case equal to the default
value (`0`), we unfortunately have to take the go implementation as the source
of truth, given that it is already released.

With the above in mind and to prevent confusion for other implementations in
languages which do not treat the non-set case equal to the default value (`0`),
this commit marks the `Reservation::expire` field as `required`.

What do folks think? If I am not mistaken, the change below is non-breaking
for the Go implementation, given that it effectlively already treats `expire` as `required`.