### PR TITLE
autonat/: Document denial of dial requests on relayed connections

### DIFF
--- a/autonat/README.md
+++ b/autonat/README.md
@@ -58,7 +58,9 @@ it uses for its regular libp2p connection to perform these dial backs.
 In order to prevent attacks like the one described in [RFC 3489, Section
 12.1.1](https://www.rfc-editor.org/rfc/rfc3489#section-12.1.1) (see excerpt
 below), implementations MUST NOT dial any multiaddress unless it is based on the
-IP address the requesting node is observed as.
+IP address the requesting node is observed as. This restriction as well implies that
+implementations MUST NOT accept dial requests via relayed connections as one can
+not validate the IP address of the requesting node.
 
 > RFC 3489 12.1.1 Attack I: DDOS Against a Target
 >


### PR DESCRIPTION
In order to uphoald the defense mechanism introduced in
048bdbfe2439058c355db612eac717fc8a46acbb one should not accept dial requests via
relayed connections.

Follow up on the discussion https://github.com/libp2p/specs/pull/362#issuecomment-978964384.

//CC @elenaf9