### PR TITLE
add the WebTransport effort to the roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,6 +21,7 @@ third-party ownership of data.
         - [🤖 libp2p as a WASM library](#🤖-libp2p-as-a-wasm-library)
     - [Evolve](#evolve)
         - [🕸 Unprecedented global connectivity](#🕸-unprecedented-global-connectivity)
+        - [✈️ WebTransport](#✈️-webtransport)
         - [⏱ Full Observability](#⏱-full-observability)
         - [🧪 Automated compatibility testing](#🧪-automated-compatibility-testing)
         - [🤝 Low latency, efficient connection handshake](#🤝-low-latency-efficient-connection-handshake)
@@ -252,6 +253,27 @@ rest of the system.
 - [NAT traversal tracking issue](https://github.com/libp2p/specs/issues/312).
 
 - [WebRTC tracking issue](https://github.com/libp2p/specs/issues/220)
+
+
+### ✈️ WebTransport
+
+**Status**: In progress
+
+**What?** WebTransport is a browser-API offering low-latency, bidirectional
+client-server messaging running on top of QUIC. The browser API allows the
+establishment of connections to servers that don't have a TLS certificate
+signed by a certificate authority if the hash of the certificate is known in
+advance.
+
+**Why?** This allows libp2p nodes running in the browser (using js-libp2p) to
+connect to the rest of the libp2p network.
+
+**Links:**
+
+- [IETF draft](https://datatracker.ietf.org/doc/draft-ietf-webtrans-http3/)
+- [W3C Browser API](https://w3c.github.io/webtransport/)
+- [libp2p spec discussion](https://github.com/libp2p/specs/pull/404)
+- [webtransport-go](https://github.com/marten-seemann/webtransport-go/)
 
 ### ⏱ Full Observability
 


### PR DESCRIPTION
My experimentation with WebTransport shows that there are no blockers to getting this implemented an rolled out. In fact, webtransport-go is able to communicate with browser nodes, and we have resolved the peer authentication issue in https://github.com/libp2p/specs/pull/404, even avoiding double encryption.

95% of the complexity of getting this implemented is on the Go side, and the remaining 5% on the JS side. If we want to prioritize this effort, the remaining work on the Go side is ~1-2 weeks, and 1-2 days on the JS side.
On the Rust side, this will probably be a lot harder to get going, considering that rust-libp2p doesn't have a QUIC implementation yet, let alone a WebTransport implementation. However, we don't need to implement this in rust-libp2p (for now), we can already reap the benefits of connection js-libp2p to go-libp2p nodes, at least in the IPFS and the Filecoin network.