### PR TITLE
ROADMAP.md: Mark hole punching on TCP and QUIC as done

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,8 +20,7 @@ third-party ownership of data.
         - [📮 Offline message queue / postbox](#📮-offline-message-queue--postbox)
         - [🤖 libp2p as a WASM library](#🤖-libp2p-as-a-wasm-library)
     - [Evolve](#evolve)
-        - [🕸 Unprecedented global connectivity](#🕸-unprecedented-global-connectivity)
-        - [⏱ Full Observability](#⏱-full-observability)
+        - [⏱ Full Observability](#-full-observability)
         - [🧪 Automated compatibility testing](#🧪-automated-compatibility-testing)
         - [🤝 Low latency, efficient connection handshake](#🤝-low-latency-efficient-connection-handshake)
         - [🛣️ Peer Routing Records](#🛣️-peer-routing-records)
@@ -35,6 +34,8 @@ third-party ownership of data.
         - [☎️ Reducing the dial fail rate](#️-reducing-the-dial-fail-rate)
         - [🔀 Peer exchange protocol](#🔀-peer-exchange-protocol)
         - [🏹 RPC and other common node communication patterns](#🏹-rpc-and-other-common-node-communication-patterns)
+    - [Done](#done)
+        - [🕸 Hole punching on TCP and QUIC](#🕸-hole-punching-on-tcp-and-quic)
 
 ## Visionary
 
@@ -222,36 +223,6 @@ model.
 **Our short-term roadmap**.
 
 This is the stuff pushing the existing libp2p stack forward.
-
-### 🕸 Unprecedented global connectivity
-
-**Status**: In progress
-
-**What?** A DHT crawl measurements (Nov 22nd 2019) showed that out
-of 4344 peers, 2754 were undialable (\~63%). This evidence correlates
-with feedback from the IPFS and Filecoin teams.
-
-We need to implement additional mechanisms for Firewall and NAT traversal to
-have the highest probability of being able to establish a direct connection.
-Mechanisms we wish to add include:
-
-- Project Flare stack (via *Circuit Relay v2*, *Direct Connection Upgrade
-  through Relay*, *AutoNAT*, *Stream Migration*, ...)
-
-- WebRTC
-
-**Why?** Good connectivity is the bread-and-butter of libp2p. Focusing
-on solving these issues will bring more stability and robustness to the
-rest of the system.
-
-**Links:**
-
-- [Hole punching long-term
-  vision](https://github.com/mxinden/specs/blob/hole-punching/connections/hole-punching.md).
-
-- [NAT traversal tracking issue](https://github.com/libp2p/specs/issues/312).
-
-- [WebRTC tracking issue](https://github.com/libp2p/specs/issues/220)
 
 ### ⏱ Full Observability
 
@@ -618,3 +589,31 @@ networking to get started with libp2p.
 [libp2p specification]: https://github.com/libp2p/specs/
 [testground project]: https://github.com/testground/testground
 [libp2p test-plans repository]: https://github.com/libp2p/test-plans
+
+## Done
+
+### 🕸 Hole punching on TCP and QUIC
+
+**Status**: Done
+
+**What?** A DHT crawl measurements (Nov 22nd 2019) showed that out
+of 4344 peers, 2754 were undialable (\~63%). This evidence correlates
+with feedback from the IPFS and Filecoin teams.
+
+We need to implement additional mechanisms for Firewall and NAT traversal to
+have the highest probability of being able to establish a direct connection.
+Mechanisms we wish to add include:
+
+- Project Flare stack (via *Circuit Relay v2*, *Direct Connection Upgrade
+  through Relay*, *AutoNAT*, *Stream Migration*, ...)
+
+**Why?** Good connectivity is the bread-and-butter of libp2p. Focusing on
+solving these issues for TCP and QUIC will bring more stability and robustness
+to the rest of the system.
+
+**Links:**
+
+- [Hole punching long-term
+  vision](https://github.com/mxinden/specs/blob/hole-punching/connections/hole-punching.md).
+
+- [NAT traversal tracking issue](https://github.com/libp2p/specs/issues/312).


### PR DESCRIPTION
- Introduce "Done" section.
- Reduce scope of "Unprecedented global connectivity" to hole punching on QUIC
  and TCP.
- Move item down to "Done" section.

Browser connectivity is tracked via https://github.com/libp2p/specs/pull/407/ and https://github.com/libp2p/specs/pull/414. I will add an additional pull request to track stream migration. Testing will be tracked via "Automated compatibility testing" section.

_As far as I remember, this is what we agreed on in Paris. Please correct me in case I am wrong._