### PR TITLE
ROADMAP.md: Add stream migration protocol

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,6 +23,7 @@ third-party ownership of data.
         - [🕸 Unprecedented global connectivity](#🕸-unprecedented-global-connectivity)
         - [⏱ Full Observability](#⏱-full-observability)
         - [🧪 Automated compatibility testing](#🧪-automated-compatibility-testing)
+        - [Stream Migration Protocol](#stream-migration-protocol)
         - [🤝 Low latency, efficient connection handshake](#🤝-low-latency-efficient-connection-handshake)
         - [🛣️ Peer Routing Records](#🛣️-peer-routing-records)
         - [🗣️ Polite peering](#🗣️-polite-peering)
@@ -289,6 +290,18 @@ the [libp2p test-plans repository].
 **Links:**
 
 - [First proof of concept](https://github.com/libp2p/test-plans/pull/20)
+
+### Stream Migration Protocol
+
+**What?** A protocol to migrate a stream from one connection to another.
+
+**Why?** Among others, this allows the migration of streams from a relayed
+connection to a direct connection.
+
+**Links:***
+
+- Tracking issue https://github.com/libp2p/specs/issues/328
+- Specification draft https://github.com/libp2p/specs/pull/406#discussion_r852835671
 
 ### 🤝 Low latency, efficient connection handshake
 


### PR DESCRIPTION
_As discussed in Paris, tracking the stream migration protocol in a separate roadmap item, instead of the "Unprecedented global connectivity" item. Note that the latter is being moved to "done" in https://github.com/libp2p/specs/pull/415._