### PR TITLE
pubsub/gossipsub: Update rust-libp2p supporting v1.1

### DIFF
--- a/pubsub/gossipsub/README.md
+++ b/pubsub/gossipsub/README.md
@@ -26,7 +26,7 @@ Legend: ✅ = complete, 🏗 = in progress, ❕ = not started yet
 |--------------------------------------------------------------------------------------------------|:-----:|:-----:|
 | [go-libp2p-pubsub (Golang)](https://github.com/libp2p/go-libp2p-pubsub/blob/master/gossipsub.go) |   ✅  |   ✅  |
 | [js-libp2p-gossipsub (JavaScript)](https://github.com/ChainSafe/js-libp2p-gossipsub)                    |   ✅  |   ✅  |
-| [rust-libp2p (Rust)](https://github.com/libp2p/rust-libp2p/tree/master/protocols/gossipsub)      |   ✅ |   🏗  |
+| [rust-libp2p (Rust)](https://github.com/libp2p/rust-libp2p/tree/master/protocols/gossipsub)      |   ✅ |   ✅  |
 | [py-libp2p (Python)](https://github.com/libp2p/py-libp2p/tree/master/libp2p/pubsub)              |   ✅  |   🏗  |
 | [jvm-libp2p (Java/Kotlin)](https://github.com/libp2p/jvm-libp2p/tree/develop/src/main/kotlin/io/libp2p/pubsub) |   ✅  |   🏗  |
 | [nim-libp2p (Nim)](https://github.com/status-im/nim-libp2p/blob/master/libp2p/protocols/pubsub/gossipsub.nim) |   ✅  |   🏗  |


### PR DESCRIPTION
To the best of my knowledge, the Gossipsub implementation in rust-libp2p supports Gossipsub v1.1.

@AgeManning can you confirm? Am I missing something?

Follow up to https://github.com/libp2p/rust-libp2p/discussions/2825#discussioncomment-3430068.