### PR TITLE
New values for DHT Provider Record Republish and Expiration (22h/48h, RFM17)

### DIFF
--- a/kad-dht/README.md
+++ b/kad-dht/README.md
@@ -279,9 +279,9 @@ heuristic of the value to make the decision.
 There are two things at play with regard to provider record (and therefore content)
 liveness and reachability:
 
-Content providers need to make sure that their content is reachable, despite peer churn;
-and nodes that store and serve provider records need to make sure that the Multihashes whose 
-records they store are still served by the content provider.
+Content needs to be reachable, despite peer churn;
+and nodes that store and serve provider records should not serve records for stale content,
+i.e., content that the original provider does not wish to make available anymore.
 
 The following two parameters help cover both of these cases.
 1. **Provider Record Republish Interval:** The content provider 

--- a/kad-dht/README.md
+++ b/kad-dht/README.md
@@ -2,7 +2,7 @@
 
 | Lifecycle Stage | Maturity       | Status | Latest Revision |
 |-----------------|----------------|--------|-----------------|
-| 3A              | Recommendation | Active | r1, 2021-10-30  |
+| 3A              | Recommendation | Active | r2, 2022-12-09  |
 
 Authors: [@raulk], [@jhiesey], [@mxinden]
 
@@ -284,21 +284,26 @@ and nodes that store and serve provider records should not serve records for sta
 i.e., content that the original provider does not wish to make available anymore.
 
 The following two parameters help cover both of these cases.
+
 1. **Provider Record Republish Interval:** The content provider 
 needs to make sure that the nodes chosen to store the provider record 
 are still online when clients ask for the record. In order to 
 guarantee this, while taking into account the peer churn, content providers
 republish the records they want to provide. Choosing the particular value for the
 Republish interval is network-specific and depends on several parameters, such as
-peer reliability and churn. For the IPFS network it is currently set to 22 hours.
+peer reliability and churn.
+
+   - For the IPFS network it is currently set to **22 hours**.
+
 2. **Provider Record Expiration Interval:** The network needs to provide
 content that content providers are still interested in providing. In other words,
 nodes should not keep records for content that content providers have stopped 
 providing (aka stale records). In order to guarantee this, provider records 
 should _expire_ after some interval, i.e., nodes should stop serving those records, 
 unless the content provider has republished the provider record. Again, the specific
-setting depends on the characteristics of the network. In the IPFS DHT the Expiration 
-Interval is set to 48hrs.
+setting depends on the characteristics of the network.
+
+   - In the IPFS DHT the Expiration Interval is set to **48 hours**.
 
 The values chosen for those parameters should be subject to continuous monitoring 
 and investigation. Ultimately, the values of those parameters should balance 

--- a/kad-dht/README.md
+++ b/kad-dht/README.md
@@ -272,7 +272,7 @@ There are two things at play with regard to provider record (and therefore conte
 liveness and reachability:
 
 Content providers need to make sure that their content is reachable, despite peer churn
-and nodes that store and serve provider records need to make sure that the CIDs whose 
+and nodes that store and serve provider records need to make sure that the Multihashes whose 
 records they store are still served by the content provider.
 
 The following two parameters help cover both of these cases.

--- a/kad-dht/README.md
+++ b/kad-dht/README.md
@@ -305,7 +305,7 @@ key, the DHT finds the (`k` = 20) closest peers to the key using the `FIND_NODE`
 [peer routing section](#peer-routing)), and then sends an `ADD_PROVIDER` RPC with
 its own `PeerInfo` to each of these peers. The study in [provider-record-measurements]
 proved that the replication factor of `k` = 20 is a good setting, although continuous
-monitoring and investigation.
+monitoring and investigation may change this recommendation in the future.
 
 Each peer that receives the `ADD_PROVIDER` RPC should validate that the received
 `PeerInfo` matches the sender's `peerID`, and if it does, that peer should store

--- a/kad-dht/README.md
+++ b/kad-dht/README.md
@@ -311,8 +311,8 @@ Each peer that receives the `ADD_PROVIDER` RPC should validate that the received
 `PeerInfo` matches the sender's `peerID`, and if it does, that peer should store
 the `PeerInfo` in its datastore. Implementations may choose to not store the
 addresses of the providing peer e.g. to reduce the amount of required storage or
-to prevent storing potentially outdated address information. In the current implementation
-peers keep the network address (i.e., the `multiaddress`) of the providing peer for **the
+to prevent storing potentially outdated address information. Implementations that choose
+to keep the network address (i.e., the `multiaddress`) of the providing peer should do it for **the
 first 10 mins** after the provider record (re-)publication. The setting of 10 mins follows
 the DHT Routing Table refresh interval. After that, peers provide 
 the provider's `peerID` only, in order to avoid pointing to stale network addresses 


### PR DESCRIPTION
This PR updates the description of the Provider Record settings and most importantly proposes new values for both the republish interval and the expiration interval. The new proposed values are:

- republish interval to be set to 24hrs, from its current 12hrs
- expiration interval to be set to 48hrs, from its current 

and they are based on the comprehensive study published here: https://github.com/protocol/network-measurements/blob/master/results/rfm17-provider-record-liveness.md