### PR TITLE
noise: introduce an extension registry

### DIFF
--- a/noise/README.md
+++ b/noise/README.md
@@ -219,8 +219,6 @@ syntax = "proto2";
 
 message NoiseExtensions {
     repeated bytes webtransport_certhashes = 1;
-    optional bytes webrtc_fingerprint = 2;
-    repeated string stream_muxers = 3; 
 }
 
 message NoiseHandshakePayload {

--- a/noise/README.md
+++ b/noise/README.md
@@ -200,16 +200,17 @@ The Noise Protocol Framework caters for sending early data alongside handshake
 messages. We leverage this construct to transmit:
 
 1. the libp2p identity key along with a signature, to authenticate each party to
-   the other, and
-2. extensions to the Noise handshake
+   the other.
+2. extensions used by the libp2p stack.
 
-Note that when sending extensions with the first message of the handshake
-pattern, the data is transmitted unencrypted. When sending the payload in
-message 3 (closing message), for the initiator, and in message 2, for the
-responder, the data will be send encrypted with forward secrecy.
-It should be stressed, that while the second message of the handshake pattern
-has forward secrecy, the sender has not yet authenticated the responder,
-so this payload might be sent to any party, including an active attacker.
+The extensions are inserted into the first message of the handshake pattern
+**that guarantees secrecy**. Specifically, this means that the initiator MUST NOT
+send extensions in their first message. 
+The initiator sends its extensions in message 3 (closing message), and the 
+responder sends theirs in message 2 (their only message). It should be stressed,
+that while the second message of the handshake pattern has forward secrecy, 
+the sender has not authenticated the responder yet, so this payload might be
+sent to any party, including an active attacker.
 
 When decrypted, the payload contains a serialized [protobuf][protobuf]
 `NoiseHandshakePayload` message with the following schema:

--- a/noise/README.md
+++ b/noise/README.md
@@ -452,6 +452,14 @@ unsupported types like RSA.
 - Removed Noise Pipes and related handshake patterns
 - Removed padding within encrypted payloads
 
+### r3 - 2022-09-20
+
+- Change Protobuf definition to proto2 (due to the layout of the protobuf used, this is backwards-compatible change)
+
+### r4 - 2022-09-22
+
+- Add Noise extension registry
+
 
 [peer-id-spec]: ../peer-ids/peer-ids.md
 [peer-id-spec-signing-rules]: ../peer-ids/peer-ids.md#how-keys-are-encoded-and-messages-signed

--- a/noise/README.md
+++ b/noise/README.md
@@ -292,10 +292,9 @@ mechanism, this specification defines an extension registry, modeled after
 [RFC 9000](https://datatracker.ietf.org/doc/html/rfc9000#section-19.21)
 (for QUIC).
 
-This spec currently defines 3 extension code points for the `NoiseExtensions`
-protobuf. Note that this document only defines the code point, and leaves
-it up to the protocol using that code point to define semantics associated
-with that code point.
+Note that this document only defines the `NoiseExtensions` code points, and
+leaves it up to the protocol using that code point to define semantics
+associated with these code point.
 
 Code points above 1024 MAY be used for experimentation. Code points up to
 this value MUST be registered in this document before deployment.


### PR DESCRIPTION
Fixes #450.

This PR removes the `data` field from the `NoiseHandshakePayload` protobuf, and adds an `extensions` field. `extensions` is `NoiseExtensions` protobuf, modeled after the extension registries that TLS and QUIC use.
By using a new ID (`data` was 3, `extensions` is 4), this change won’t break implementations that used early data (I’m not aware of any, but just in case).

I’ve added code points for WebTransport, WebRTC and Early Muxer Negotiation to this PR, mostly to demonstrate how this would look like. Given that none of the specs for these are merged yet, it might make sense to define an empty `NoiseExtensions` protobuf here, and have the respective PRs add their code point (we’ll have to deal with merge conflicts then). Let me know if I should make that change.