### PR TITLE
noise: specify proto2

### DIFF
--- a/noise/README.md
+++ b/noise/README.md
@@ -5,7 +5,7 @@
 
 | Lifecycle Stage | Maturity       | Status | Latest Revision |
 |-----------------|----------------|--------|-----------------|
-| 3A              | Recommendation | Active | r2, 2020-03-30  |
+| 3A              | Recommendation | Active | r3, 2022-09-20  |
 
 Authors: [@yusefnapora]
 

--- a/noise/README.md
+++ b/noise/README.md
@@ -220,9 +220,9 @@ When decrypted, the payload contains a serialized [protobuf][protobuf]
 syntax = "proto2";
 
 message NoiseHandshakePayload {
-  bytes identity_key = 1;
-  bytes identity_sig = 2;
-  bytes data         = 3;
+  optional bytes identity_key = 1;
+  optional bytes identity_sig = 2;
+  optional bytes data         = 3;
 }
 ```
 

--- a/noise/README.md
+++ b/noise/README.md
@@ -217,6 +217,8 @@ When decrypted, the payload contains a serialized [protobuf][protobuf]
 `NoiseHandshakePayload` message with the following schema:
 
 ``` protobuf
+syntax = "proto2";
+
 message NoiseHandshakePayload {
   bytes identity_key = 1;
   bytes identity_sig = 2;


### PR DESCRIPTION
Proto2 allows us to distinguish between unset and default values, which Proto3 doesn't. Since the protobuf we used for Noise was that simple, the serialization is compatible, so we can change to Proto2, even though some implementations interpreted the Protobuf defined here as Proto3.

I confirmed that a node running v0.22.0 (using a proto3 protobuf) can connect to a node using the proto2 protobuf, and vice versa.

### Server

```go
func main() {
	h1, err := libp2p.New(
		libp2p.ListenAddrStrings("/ip4/127.0.0.1/tcp/1234"),
		libp2p.Security("noise", noise.New),
	)
	if err != nil {
		log.Fatal(err)
	}
	fmt.Println("I am:", h1.ID())

	h1.SetStreamHandler("/proto1", func(str network.Stream) {
		data, err := io.ReadAll(str)
		if err != nil {
			log.Fatal(err)
		}
		fmt.Println("received data for proto1:", string(data))
	})
	select {}
}
```

client (using the ID printed by the server):
```go
func main() {
	id, err := peer.Decode("QmcWzKr7pPn7TXc5rYiW6YtLSHBc1Bjw3ScvUK9wHn4rgW")
	if err != nil {
		log.Fatal(err)
	}
	addr := ma.StringCast("/ip4/127.0.0.1/tcp/1234")

	h2, err := libp2p.New(
		libp2p.ListenAddrStrings("/ip4/127.0.0.1/tcp/1235"),
		libp2p.Security("noise", noise.New),
	)
	if err != nil {
		log.Fatal(err)
	}
	if err := h2.Connect(context.Background(), peer.AddrInfo{
		ID:    id,
		Addrs: []ma.Multiaddr{addr},
	}); err != nil {
		log.Fatal(err)
	}

	str, err := h2.NewStream(context.Background(), id, "/proto1")
	if err != nil {
		log.Fatal(err)
	}
	str.Write([]byte("foobar"))
	str.Close()
	select {}
}
```