### PR TITLE
roadmap: rewrite the section about efficient handshakes

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -322,21 +322,19 @@ be achieved with the [WebTransport](#✈️-webtransport) protocol.
 **High priority for: IPFS**
 
 **What?** Establishing a connection and performing the initial handshake
-should be as cheap and fast as possible. Supporting things like
-*selective* stream opening, *preemption*, *speculative* negotiation,
-*upfront* negotiation, protocol table *pinning*, etc. may enable us to
-achieve lower latencies when establishing connections, and even the
-0-RTT holy grail in some cases. These features are being discussed in
-the *Protocol Select* protocol design.
+should be as cheap and fast as possible. On TCP, The current libp2p
+handshakes spends one round-trip negotiating the security protocol, and
+another roundtrip negotiating the stream multiplexer.
+By using advanced features of the handshake protocol, we might even be
+able to reach the holy grail of a 0-RTT handshake in some cases.
 
-**Why?** Multistream 1.0 is chatty and naïve. Streams are essential to
-libp2p, and negotiating them is currently inefficient in a number of
-scenarios. Also, bootstrapping a multiplexed connection is currently
-guesswork (we test protocols one by one, incurring in significant
-ping-pong).
+**Why?** Applications rely on quick connection establishment. libp2p
+shouldn't make them wait for any longer than absolutely necessary.
 
 **Links:**
 
+- [security protocol in multiaddr](https://github.com/libp2p/specs/pull/353)
+- [muxer selection in security handshake](https://github.com/libp2p/specs/pull/446)
 - [Protocol Select specification](https://github.com/libp2p/specs/pull/349)
 
 ### 🛣️ Peer Routing Records

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -322,9 +322,9 @@ be achieved with the [WebTransport](#✈️-webtransport) protocol.
 **High priority for: IPFS**
 
 **What?** Establishing a connection and performing the initial handshake
-should be as cheap and fast as possible. On TCP, The current libp2p
-handshakes spends one round-trip negotiating the security protocol, and
-another roundtrip negotiating the stream multiplexer.
+should be as cheap and fast as possible. On TCP, the current libp2p
+handshake spends one round-trip negotiating the security protocol, and
+another round-trip negotiating the stream multiplexer.
 By using advanced features of the handshake protocol, we might even be
 able to reach the holy grail of a 0-RTT handshake in some cases.
 
@@ -333,8 +333,8 @@ shouldn't make them wait for any longer than absolutely necessary.
 
 **Links:**
 
-- [security protocol in multiaddr](https://github.com/libp2p/specs/pull/353)
-- [muxer selection in security handshake](https://github.com/libp2p/specs/pull/446)
+- [Security protocol in multiaddr](https://github.com/libp2p/specs/pull/353)
+- [Muxer selection in security handshake](https://github.com/libp2p/specs/pull/446)
 - [Protocol Select specification](https://github.com/libp2p/specs/pull/349)
 
 ### 🛣️ Peer Routing Records


### PR DESCRIPTION
Over the last couple of weeks, we've broken the early muxer negotiation into its own project (#446), and found an arguably nicer solution than proposed in the Protocol Select spec (#349). The change to move the security address into the multiaddr is already split out into a separate PR: #354.

With these two changes having been separated from Protocol Select, we save 2 RTTs during a TCP handshake, reducing the total latency to the bare minimum consumed by the components used (TCP: 1 RTT, security handshake: 1 RTT).

Implementing the rest of the Protocol Select spec now appears less pressing. The main additional benefits would be:
1. Slightly shorter protocol names, since the protocol string would be wrapped in a protobuf instead of being prefixed with `/multistream/1.0.0`. This saving of ~10 bytes on a new stream is likely negligible in almost all situations.
2. The ability to propose multiple protocols on a stream at the same time, instead of sequentially. In theory, this saves roundtrips, but in practice, one can just open multiple streams, one for each of the protocols (and then even send application data right away, if desired).
3. The Protocol Select protobuf is as a basis for future extensions to the protocol, e.g. an extension that abbreviates protocol IDs with an integer, saving another ~10 bytes per stream.

(1) and (2) probably don't justify a high priority for Protocol Select. (3) is a valid point, but it would be preferable if the project was driving by a concrete use case that in itself would justify a high priority, rather than by the wish to create an extensible platform.