### PR TITLE
Introduce `perf` spec

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,53 +1,72 @@
-# Roadmap
+# Roadmap <!-- omit in toc -->
 
 The libp2p project is creating a set of modular, loosely-coupled building blocks
 (based on a shared core) for modern peer-to-peer networking. Our goal is to
 enable a new generation of decentralized applications in which network nodes are
-full peers, providing and consuming data, and routing traffic for one another,
-all without the need for centralized infrastructure points or reliance on
-third-party ownership of data.
+full peers, provide and consume data, and route traffic for one another,
+all without the need for centralized infrastructure or reliance on
+third-party data ownership.
 
-**Table of Contents**
+## Table of Contents <!-- omit in toc -->
 
-- [Roadmap](#roadmap)
-    - [Visionary](#visionary)
-        - [🖧 Decentralizing networks](#🖧-decentralizing-networks)
-        - [🤫 A spyproof libp2p](#🤫-a-spyproof-libp2p)
-        - [📱 libp2p in mobile devices](#📱-libp2p-in-mobile-devices)
-        - [💡 libp2p in IoT](#💡-libp2p-in-iot)
-        - [🎓 libp2p as a platform for Networks Research & Innovation](#🎓-libp2p-as-a-platform-for-networks-research--innovation)
-        - [🚑 Self-healing networks](#🚑-self-healing-networks)
-        - [📮 Offline message queue / postbox](#📮-offline-message-queue--postbox)
-        - [🤖 libp2p as a WASM library](#🤖-libp2p-as-a-wasm-library)
-    - [Evolve](#evolve)
-        - [✈️ WebTransport](#✈️-webtransport)
-        - [⏱ Full Observability](#⏱-full-observability)
-        - [🧪 Automated compatibility testing](#🧪-automated-compatibility-testing)
-        - [Stream Migration Protocol](#stream-migration-protocol)
-        - [WebRTC](#webrtc)
-        - [🤝 Low latency, efficient connection handshake](#🤝-low-latency-efficient-connection-handshake)
-        - [🛣️ Peer Routing Records](#🛣️-peer-routing-records)
-        - [🗣️ Polite peering](#🗣️-polite-peering)
-        - [🧱 Composable routing](#🧱-composable-routing)
-        - [💣 Attack resistance, threat models and security](#💣-attack-resistance-threat-models-and-security)
-        - [📈 Proving we are scalable and interoperable](#📈-proving-we-are-scalable-and-interoperable)
-        - [🌡️ Telemetry protocol](#🌡️-telemetry-protocol)
-        - [📩 Message-oriented transports](#📩-message-oriented-transports)
-        - [☎️ Reducing the dial fail rate](#️-reducing-the-dial-fail-rate)
-        - [🔀 Peer exchange protocol](#🔀-peer-exchange-protocol)
-        - [🏹 RPC and other common node communication patterns](#🏹-rpc-and-other-common-node-communication-patterns)
-    - [Done](#done)
-        - [🕸 Hole punching on TCP and QUIC](#🕸-hole-punching-on-tcp-and-quic)
+- [Core Tenets](#core-tenets)
+  - [Implementation Roadmaps](#implementation-roadmaps)
+- [Visionary](#visionary)
+  - [🖧 Decentralizing networks](#-decentralizing-networks)
+  - [🤫 A spyproof libp2p](#-a-spyproof-libp2p)
+  - [📱 libp2p in mobile devices](#-libp2p-in-mobile-devices)
+  - [💡 libp2p in IoT](#-libp2p-in-iot)
+  - [🎓 libp2p as a platform for Networks Research & Innovation](#-libp2p-as-a-platform-for-networks-research--innovation)
+  - [🚑 Self-healing networks](#-self-healing-networks)
+  - [📮 Offline message queue / postbox](#-offline-message-queue--postbox)
+- [Evolve](#evolve)
+  - [✈️ WebTransport](#️-webtransport)
+  - [⏱ Full Observability](#-full-observability)
+  - [🧪 Automated compatibility testing](#-automated-compatibility-testing)
+  - [Stream Migration Protocol](#stream-migration-protocol)
+  - [WebRTC](#webrtc)
+  - [🤖 libp2p as a Wasm library](#-libp2p-as-a-wasm-library)
+  - [🤝 Low latency, efficient connection handshake](#-low-latency-efficient-connection-handshake)
+  - [🛣️ Peer Routing Records](#️-peer-routing-records)
+  - [🗣️ Polite peering](#️-polite-peering)
+  - [🧱 Composable routing](#-composable-routing)
+  - [💣 Attack resistance, threat models and security](#-attack-resistance-threat-models-and-security)
+  - [📈 Proving we are scalable and interoperable](#-proving-we-are-scalable-and-interoperable)
+  - [🌡️ Telemetry protocol](#️-telemetry-protocol)
+  - [📩 Message-oriented transports](#-message-oriented-transports)
+  - [☎️ Reducing the dial fail rate](#️-reducing-the-dial-fail-rate)
+  - [🔀 Peer exchange protocol](#-peer-exchange-protocol)
+  - [🏹 RPC and other common node communication patterns](#-rpc-and-other-common-node-communication-patterns)
+- [Done](#done)
+  - [🕸 Hole punching on TCP and QUIC](#-hole-punching-on-tcp-and-quic)
+
+## Core Tenets
+Before we dive into what libp2p should support and enable, let's outline the core tenets that underpin the project. As maintainers, we commit to ensuring libp2p is:
+- 🔒 Secure - Building on libp2p *improves* an application's security posture. We minimize vulnerabilities and act rapidly to address and report issues.
+- 🪨 Stable - Releases do not unknowingly break deployed features. We maintain cross-version compatibility across libp2p releases and implementations. Deprecations are well-communicated.
+- 🥽 Specified - We thoroughly specify the libp2p framework and its suite of supported protocols, independent of language or implementation. Through specifications, we coordinate and drive future developments.
+- 🚀 Performant - We ensure comparable performance to widely used protocols on the Internet. We avoid performance degradations in new releases.
+
+These tenets form the foundation for features and initiatives listed below.  As a result, we generally prioritize filling any gaps in these tenets above other work.
+
+### Implementation Roadmaps
+
+This roadmap doesn't provide a timeline for project adoption across libp2p implementations. For specific sequencing and dates, see the different implementation roadmaps:
+- [libp2p/test-plans](https://github.com/libp2p/test-plans/blob/master/ROADMAP.md)
+- [go-libp2p](https://github.com/libp2p/go-libp2p/blob/master/ROADMAP.md)
+- [js-libp2p](https://github.com/libp2p/js-libp2p/blob/master/ROADMAP.md)
+- [rust-libp2p](https://github.com/libp2p/rust-libp2p/blob/master/ROADMAP.md)
+* (other implementations: feel free to add)
 
 ## Visionary
 
 **Our long term roadmap**.
 
-This is the stuff that moves libp2p from "a networking toolbox to build P2P
-applications" to the thing that fundamentally reshapes the architecture of the
-Internet; our dreams and aspirations, the North star we should always keep in
-sight; this is what motivates us and it speaks intimately to our mission
-statement; the libp2p analogy of IPFS working on Mars
+These are the goals that move libp2p from "a networking toolbox for building P2P
+applications" to a project that fundamentally reshapes the architecture of the
+Internet. They are our dreams, aspirations, and the North star we should always keep in
+sight. This is what motivates us and it speaks intimately to our mission
+statement; the libp2p analogy of [IPFS working on Mars](https://github.com/ipfs/roadmap/blob/master/README.md#-interplanetary-web---mars-2024-d3-e3-i4).
 
 ### 🖧 Decentralizing networks
 
@@ -192,39 +211,11 @@ roaming, etc.
 
 -   https://github.com/libp2p/notes/issues/2
 
-### 🤖 libp2p as a WASM library
-
-**What?** This point encompasses two things:
-
-1. Preparing [existing
-   implementations](https://github.com/libp2p/rust-libp2p/issues/23) to run in
-   WASM environments (mainly the browser).
-
-2. Evaluating if it's feasible to build a canonical implementation of
-   libp2p, that is maintained in a single language, compiling down to
-   WebAssembly so that it can be used from any other programming
-   language -- as long as the user is building a WASM application.
-   (The feasibility of this idea is unknown as this time;
-   particularly the VM doesn't expose a socket API, but the
-   Emscripten SDK emulates IP sockets over WebSockets.)
-
-**Why?** Aside from targeting WASM use cases, having one canonical
-implementation of libp2p that can *run anywhere* could help focus the
-team's time on building new features, instead of keeping a multitude of
-implementations across different languages in sync, i.e. create more
-value and impact. WASM also presents a huge vector for making libp2p the
-de-facto networking stack, for cases where WASM is a suitable deployment
-model.
-
-**Links:**
-
-- [WASM support in rust-libp2p](https://github.com/libp2p/rust-libp2p/issues/23).
-
 ## Evolve
 
 **Our short-term roadmap**.
 
-This is the stuff pushing the existing libp2p stack forward.
+These are the projects pushing the existing libp2p stack forward.
 
 ### ✈️ WebTransport
 
@@ -315,6 +306,31 @@ be achieved with the [WebTransport](#✈️-webtransport) protocol.
 
 - Tracking issue https://github.com/libp2p/specs/issues/220
 - Specification draft https://github.com/libp2p/specs/pull/412
+
+### 🤖 libp2p as a Wasm library
+
+**What?** This point encompasses two things:
+
+1. Preparing [existing
+   implementations](https://github.com/libp2p/rust-libp2p/issues/2617) to run in
+   Wasm environments (mainly the browser).
+
+2. Evaluating if it's feasible to build a canonical implementation of
+   libp2p, that is maintained in a single language, compiling down to
+   WebAssembly so that it can be used from any other programming
+   language -- as long as the user is building a Wasm application.
+
+**Why?** Aside from targeting Wasm use cases, having one canonical
+implementation of libp2p that can *run anywhere* could help focus the
+team's time on building new features, instead of keeping a multitude of
+implementations across different languages in sync, i.e. create more
+value and impact. Wasm also presents a huge vector for making libp2p the
+de-facto networking stack, for cases where Wasm is a suitable deployment
+model.
+
+**Links:**
+
+- [Wasm support in rust-libp2p](https://github.com/libp2p/rust-libp2p/issues/2617).
 
 ### 🤝 Low latency, efficient connection handshake
 

--- a/perf/perf.md
+++ b/perf/perf.md
@@ -106,7 +106,7 @@ To run this benchmark:
 3. once a connection is established, the client closes it and establishes
    another one.
 
-handshakes per second are calculated by taking the total number of connections
+Handshakes per second are calculated by taking the total number of connections
 successfully established and divide it by the time period of the test.
 
 # Security Considerations

--- a/perf/perf.md
+++ b/perf/perf.md
@@ -45,7 +45,8 @@ Client:
 1. Open a libp2p stream to the server.
 2. Tell the server how many bytes we want the server to send us as a single
    big-endian uint64 number. Zero is a valid number, so is the max uint64 value.
-3. Optional: Write some amount of data to the stream.
+3. Write some amount of data to the stream.
+     Zero is a valid amount.
 4. Close the write side of our stream.
 5. Read from the read side of the stream. This
    should be the same number of bytes as we told the server in step 2.

--- a/perf/perf.md
+++ b/perf/perf.md
@@ -1,0 +1,121 @@
+# Perf <!-- omit in toc -->
+
+| Lifecycle Stage | Maturity      | Status | Latest Revision |
+| --------------- | ------------- | ------ | --------------- |
+| 1A              | Working Draft | Active | r0, 2022-11-16  |
+
+Authors: [@marcopolo]
+
+Interest Group: [@marcopolo], [@mxinden], [@marten-seemann]
+
+[@marcopolo]: https://github.com/mxinden
+[@mxinden]: https://github.com/mxinden
+[@marten-seemann]: https://github.com/marten-seemann
+
+# Table of Contents <!-- omit in toc -->
+- [Context](#context)
+- [Protocol](#protocol)
+- [Benchmarks](#benchmarks)
+  - [Single connection throughput](#single-connection-throughput)
+  - [Handshakes per second](#handshakes-per-second)
+- [Security Considerations](#security-considerations)
+- [Prior Art](#prior-art)
+
+# Context
+
+The `perf` protocol represents a standard benchmarking protocol that we can use
+to talk about performance within and across libp2p implementations. This lets us
+analyze peformance, guide improvements, and protect against regressions.
+
+# Protocol
+
+The `/perf/1.0.0` protocol (from here on referred to as simply `perf`) is a
+client driven set of benchmarks. To not reinvent the wheel, this perf protocol
+is almost identical to Nick Bank's [_QUIC Performance_
+Internet-Draft](https://datatracker.ietf.org/doc/html/draft-banks-quic-performance#section-2.3)
+but adapted to libp2p.
+
+
+The protocol is as a follows:
+
+Client:
+
+1. Open a libp2p stream to the server.
+2. Tell the server how many bytes we want the server to send us as a single
+   big-endian uint64 number. Zero is a valid number, so is the max uint64 value.
+3. Write some amount of data to the stream.
+4. Close the write side of our stream.
+5. Read from the read side of the stream. This
+   should be the same number of bytes as we told the server in step 2.
+
+Server, on handling a new `perf` stream:
+1. Read the big-endian uint64 number. This is how many bytes we'll send back.
+2. Read from the stream until we get an `EOF` (client's write side was closed).
+3. Send the number of bytes defined in step 1 back to the client.
+4. Close the stream.
+
+# Benchmarks
+
+The above protocol is flexible enough to run the following benchmarks and more.
+The exact specifics of the benchmark (e.g. how much data to download or for how
+long) are left up to the benchmark implementation. Consider these rough
+guidelines for how to run one of these benchmarks.
+
+Other benchmarks can be run with the same protocol. The following benchmarks
+have immediate usefulness, but other benchmarks can be added as we find them
+useful. Consult the [_QUIC Performance_
+Internet-Draft](https://datatracker.ietf.org/doc/html/draft-banks-quic-performance#section-2.3)
+for some other benchmarks (called _scenarios_ in the document).
+
+## Single connection throughput
+
+For an upload test, the client sets the the server response size 0 bytes, writes
+some amount of data and closes the stream.
+
+For a download test, the client sets the server response size to N bytes, and
+closes the write side of the data.
+
+The measurements are gathered and reported by the client by measuring how many
+bytes were transferred by the total time it took from stream open to stream
+close.
+
+A timer based variant is also possible where we see how much data a client can
+upload or download within a specific time. For upload it's the same as before
+and the client closes the stream after the timer ends. For download, the client
+should request a response size of max uint64, then close the stream after the
+timer ends.
+
+## Handshakes per second
+
+This benchmark measures connection setup efficiency. A transport that takes many
+RTTs will perform worse here than one that takes fewer.
+
+To run this benchmark:
+1. Set up N clients
+2. Each client opens K connections/s to a single server
+3. once a connection is established, the client closes it and establishes
+   another one.
+
+handshakes per second are calculated by taking the total number of connections
+successfully established and divide it by the time period of the test.
+
+# Security Considerations
+
+Since this protocol lets clients ask servers to do significant work, it
+SHOULD NOT be enabled by default in any implementation. Users are advised not to
+enable this on publicly reachable nodes.
+
+Authentacting by Peer ID could mitigate the security concern by only allowing
+trusted clients to use the protocol. Support for this is left to the implementation.
+
+# Prior Art
+
+As mentioned above, this document is inspired by Nick Bank's: [QUIC Performance Internet-Draft](https://datatracker.ietf.org/doc/html/draft-banks-quic-performance)
+
+[iperf](https://iperf.fr)
+
+[@mxinden's libp2p perf](https://github.com/mxinden/libp2p-perf)
+
+[@marten-seemann's libp2p perf test](https://github.com/marten-seemann/libp2p-perf-test/)
+
+[@vyzo's libp2p perf test](https://github.com/vyzo/libp2p-perf-test/)

--- a/perf/perf.md
+++ b/perf/perf.md
@@ -35,7 +35,13 @@ is almost identical to Nick Bank's [_QUIC Performance_
 Internet-Draft](https://datatracker.ietf.org/doc/html/draft-banks-quic-performance#section-2.3)
 but adapted to libp2p.
 The protocol first performs an upload of a client-chosen amount of bytes. Once
-that upload has finished, the server sends back as many bytes as the client requested.
+that upload has finished, the server sends back as many bytes as the client
+requested.
+
+The bytes themselves should be a predetermined arbitrary set of bytes. Zero is
+fine, but so is random bytes (as long as it's not a different set of random
+bytes, because then you may be limited by how fast you can generate random
+bytes).
 
 
 The protocol is as a follows:

--- a/perf/perf.md
+++ b/perf/perf.md
@@ -8,7 +8,7 @@ Authors: [@marcopolo]
 
 Interest Group: [@marcopolo], [@mxinden], [@marten-seemann]
 
-[@marcopolo]: https://github.com/mxinden
+[@marcopolo]: https://github.com/marcopolo
 [@mxinden]: https://github.com/mxinden
 [@marten-seemann]: https://github.com/marten-seemann
 
@@ -73,7 +73,7 @@ for some other benchmarks (called _scenarios_ in the document).
 
 ## Single connection throughput
 
-For an upload test, the client sets the the server response size 0 bytes, writes
+For an upload test, the client sets the the server response size to 0 bytes, writes
 some amount of data and closes the stream.
 
 For a download test, the client sets the server response size to N bytes, and


### PR DESCRIPTION
A simple protocol to run client-driven benchmarks inspired by https://datatracker.ietf.org/doc/html/draft-banks-quic-performance.