### PR TITLE
chore: proposal to update WebRTC Browser to Server to Candidate Recommendation

### DIFF
--- a/webrtc/README.md
+++ b/webrtc/README.md
@@ -363,10 +363,11 @@ accept streams before completion of the handshake.
 
 ## Previous, ongoing and related work
 
-- Work in progress implementations of this specification:
-  - https://github.com/little-bear-labs/js-libp2p-webrtc/
-  - https://github.com/libp2p/go-libp2p/pull/1655
+- Completed implementations of this specification:
   - https://github.com/libp2p/rust-libp2p/pull/2622
+- Work in progress implementations of this specification:
+  - https://github.com/little-bear-labs/js-libp2p-webrtc/pull/4
+  - https://github.com/libp2p/go-libp2p/pull/1655
 - Past related work:
   - Proof of concept for the server side (native) and the client side (Rust in
     WASM): https://github.com/wngr/libp2p-webrtc

--- a/webrtc/README.md
+++ b/webrtc/README.md
@@ -1,9 +1,8 @@
 # WebRTC
 
-| Lifecycle Stage | Maturity      | Status | Latest Revision |
-|-----------------|---------------|--------|-----------------|
-| 1A              | Working Draft | Active | r0, 2022-10-14  |
-
+| Lifecycle Stage | Maturity                  | Status | Latest Revision |
+|-----------------|---------------------------|--------|-----------------|
+| 2A              | Candidate Recommendation  | Active | r0, 2022-10-14  |
 Authors: [@mxinden]
 
 Interest Group: [@marten-seemann]
@@ -15,17 +14,20 @@ Interest Group: [@marten-seemann]
 **Table of Contents**
 
 - [WebRTC](#webrtc)
-    - [Motivation](#motivation)
-    - [Addressing](#addressing)
-    - [Connection Establishment](#connection-establishment)
-        - [Browser to public Server](#browser-to-public-server)
-    - [Multiplexing](#multiplexing)
-        - [Ordering](#ordering)
-        - [Head-of-line blocking](#head-of-line-blocking)
-        - [`RTCDataChannel` negotiation](#rtcdatachannel-negotiation)
-        - [`RTCDataChannel` label](#rtcdatachannel-label)
-    - [Connection Security](#connection-security)
-    - [Previous, ongoing and related work](#previous-ongoing-and-related-work)
+  - [Motivation](#motivation)
+  - [Addressing](#addressing)
+  - [Connection Establishment](#connection-establishment)
+    - [Browser to public Server](#browser-to-public-server)
+  - [Multiplexing](#multiplexing)
+    - [Ordering](#ordering)
+    - [Head-of-line blocking](#head-of-line-blocking)
+    - [`RTCDataChannel` negotiation](#rtcdatachannel-negotiation)
+    - [`RTCDataChannel` label](#rtcdatachannel-label)
+  - [Connection Security](#connection-security)
+  - [Previous, ongoing and related work](#previous-ongoing-and-related-work)
+  - [Test vectors](#test-vectors)
+    - [Noise prologue](#noise-prologue)
+      - [Both client and server use SHA-256](#both-client-and-server-use-sha-256)
 - [FAQ](#faq)
 
 <!-- markdown-toc end -->


### PR DESCRIPTION
### Motivation
WebRTC Transport (browser to server) has landed in rust-libp2p here https://github.com/libp2p/rust-libp2p/commit/a7148648858fe10e9ba4c2793c7e12392b49c0ab so there now exists one reference implementation.
In accordance with the [spec lifecycle](https://github.com/libp2p/specs/blob/master/00-framework-01-spec-lifecycle.md), we can update this spec from a Working Draft to a Candidate Recommendation.

### Open Questions
* How will introducing [browser to browser](https://github.com/libp2p/specs/issues/475) affect the maturity level of this spec? Previously it was specified inside this document. Perhaps it should be specified in a separate document so it can have it's own maturity level/better separation of concerns.
* Any other criteria to consider before promoting from 1A to 2A?