### PR TITLE
Add link to formal specification of GossipSub

### DIFF
--- a/pubsub/gossipsub/README.md
+++ b/pubsub/gossipsub/README.md
@@ -34,3 +34,4 @@ Legend: ✅ = complete, 🏗 = in progress, ❕ = not started yet
 Additional tooling:
 
 - Simulator developed in Gerbil: [vyzo/gerbil-simsub](https://github.com/vyzo/gerbil-simsub)
+- Formal specification developed in ACL2s: [gossipsubfm/gossipsubfm](https://github.com/gossipsubfm/gossipsubfm)


### PR DESCRIPTION
The added link goes to a full formal specification for GossipSub provided in ACL2s, an automated theorem proving environment.