### PR TITLE
identify: specify max message size

### DIFF
--- a/identify/README.md
+++ b/identify/README.md
@@ -83,6 +83,8 @@ message Identify {
 }
 ```
 
+Implementations must reject `Identify` messages bigger than 4096 bytes.
+
 ### protocolVersion
 
 The protocol version identifies the family of protocols used by the peer. The


### PR DESCRIPTION
This PR proposes specifying max size of `Identify` message to unify behavior across implementations.

Limit of 4096 bytes is based on current value in [rust-libp2p](https://github.com/libp2p/rust-libp2p/blob/5755942d7742f9d0432c346318e25da504b65370/protocols/identify/src/protocol.rs#L35), but we can pick something else.