### PR TITLE
Update circuitv2 to proto3

### DIFF
--- a/relay/circuit-v2.md
+++ b/relay/circuit-v2.md
@@ -4,7 +4,7 @@ This is the version 2 of the libp2p Circuit Relay protocol.
 
 | Lifecycle Stage | Maturity        | Status | Latest Revision |
 |-----------------|-----------------|--------|-----------------|
-| 3A              | Recommendation  | Active | r1, 2021-12-17  |
+| 3A              | Recommendation  | Active | r2, 2023-01-31  |
 
 Authors: [@vyzo]
 

--- a/relay/circuit-v2.md
+++ b/relay/circuit-v2.md
@@ -348,11 +348,11 @@ The envelope domain is `libp2p-relay-rsvp` and uses the multicodec code `0x0302`
 
 The payload of the envelope has the following form, in canonicalized protobuf format:
 ```protobuf
-syntax = "proto2";
+syntax = "proto3";
 message Voucher {
-  required bytes relay = 1;
-  required bytes peer = 2;
-  required uint64 expiration = 3;
+  bytes relay = 1;
+  bytes peer = 2;
+  uint64 expiration = 3;
 }
 ```
 - the `relay` field is the peer ID of the relay.
@@ -365,7 +365,7 @@ The wire representation is canonicalized, where elements of the message are writ
 ## Protobuf
 
 ```protobuf
-syntax = "proto2";
+syntax = "proto3";
 message HopMessage {
   enum Type {
     RESERVE = 0;
@@ -373,7 +373,7 @@ message HopMessage {
     STATUS = 2;
   }
 
-  required Type type = 1;
+  Type type = 1;
 
   optional Peer peer = 2;
   optional Reservation reservation = 3;
@@ -388,7 +388,7 @@ message StopMessage {
     STATUS = 1;
   }
 
-  required Type type = 1;
+  Type type = 1;
 
   optional Peer peer = 2;
   optional Limit limit = 3;
@@ -397,12 +397,12 @@ message StopMessage {
 }
 
 message Peer {
-  required bytes id = 1;
+  bytes id = 1;
   repeated bytes addrs = 2;
 }
 
 message Reservation {
-  required uint64 expire = 1; // Unix expiration time (UTC)
+  uint64 expire = 1; // Unix expiration time (UTC)
   repeated bytes addrs = 2;   // relay addrs for reserving peer
   optional bytes voucher = 3; // reservation voucher
 }
@@ -413,6 +413,8 @@ message Limit {
 }
 
 enum Status {
+  // zero value field required for proto3 compatibility
+  UNUSED                  = 0;
   OK                      = 100;
   RESERVATION_REFUSED     = 200;
   RESOURCE_LIMIT_EXCEEDED = 201;

--- a/relay/circuit-v2.md
+++ b/relay/circuit-v2.md
@@ -2,9 +2,9 @@
 
 This is the version 2 of the libp2p Circuit Relay protocol.
 
-| Lifecycle Stage | Maturity        | Status | Latest Revision |
-|-----------------|-----------------|--------|-----------------|
-| 3A              | Recommendation  | Active | r2, 2023-01-31  |
+| Lifecycle Stage | Maturity       | Status | Latest Revision |
+| --------------- | -------------- | ------ | --------------- |
+| 3A              | Recommendation | Active | r2, 2023-01-31  |
 
 Authors: [@vyzo]
 
@@ -350,9 +350,11 @@ The payload of the envelope has the following form, in canonicalized protobuf fo
 ```protobuf
 syntax = "proto3";
 message Voucher {
-  bytes relay = 1;
-  bytes peer = 2;
-  uint64 expiration = 3;
+  // These fields are marked optional for backwards compatibility with proto2.
+  // Users should make sure to always set these.
+  optional bytes relay = 1;
+  optional bytes peer = 2;
+  optional uint64 expiration = 3;
 }
 ```
 - the `relay` field is the peer ID of the relay.
@@ -373,7 +375,9 @@ message HopMessage {
     STATUS = 2;
   }
 
-  Type type = 1;
+  // This field is marked optional for backwards compatibility with proto2.
+  // Users should make sure to always set this.
+  optional Type type = 1;
 
   optional Peer peer = 2;
   optional Reservation reservation = 3;
@@ -388,7 +392,9 @@ message StopMessage {
     STATUS = 1;
   }
 
-  Type type = 1;
+  // This field is marked optional for backwards compatibility with proto2.
+  // Users should make sure to always set this.
+  optional Type type = 1;
 
   optional Peer peer = 2;
   optional Limit limit = 3;
@@ -397,12 +403,16 @@ message StopMessage {
 }
 
 message Peer {
-  bytes id = 1;
+  // This field is marked optional for backwards compatibility with proto2.
+  // Users should make sure to always set this.
+  optional bytes id = 1;
   repeated bytes addrs = 2;
 }
 
 message Reservation {
-  uint64 expire = 1; // Unix expiration time (UTC)
+  // This field is marked optional for backwards compatibility with proto2.
+  // Users should make sure to always set this.
+  optional uint64 expire = 1; // Unix expiration time (UTC)
   repeated bytes addrs = 2;   // relay addrs for reserving peer
   optional bytes voucher = 3; // reservation voucher
 }


### PR DESCRIPTION
Updates the circuit v2 spec to use proto3. This closes #509.