### PR TITLE
docs(relay-v2): Document that relayed conn is upgraded with sec and mux

### DIFF
--- a/relay/circuit-v2.md
+++ b/relay/circuit-v2.md
@@ -166,6 +166,9 @@ The relayed connection flows in the `hop` stream between the
 connection initiator and the relay and in the `stop` stream between
 the relay and the connection termination point.
 
+_B_ and _A_ upgrade the relayed connection with a security protocol and a
+multiplexer, just like they would e.g. upgrade a TCP connection.
+
 ### Hop Protocol
 
 The Hop protocol governs interaction between clients and the relay;


### PR DESCRIPTION
Taking a suggestion from @aschmahmann from Slack to our specs:

>> can you confirm that everything relayed is encrypted ( not just authenticated )
>
> Yeah, this should be the case. When establishing a circuit-relayed connection the connection should get "upgraded" with security and multiplexing based on whatever you have supported for other unsecured transports like TCP (e.g. TLS/Noise and mplex/yamux).
> Although AFAICT this information is missing from https://github.com/libp2p/specs/blob/master/relay/circuit-v2.md although it is described in https://github.com/libp2p/specs/blob/master/relay/circuit-v1.md. It's probably worth assuming people aren't going to read the v1 spec if they're reading v2 unless explicitly directed to, so might want to copy in some of the context and assumptions there.
> 
> Note: I get that the circuit-relay itself does not do any encryption and just gives you a dumb stream (like TCP) and the other pieces of the libp2p system will put the encryption (and multiplexing) on top. However, Riba's question is a reasonable one if you just look at the spec and https://connectivity.libp2p.io/ so might be worth highlighting. (edited)

https://filecoinproject.slack.com/archives/C03K82MU486/p1676828329616039?thread_ts=1676674830.019559&cid=C03K82MU486