### PR TITLE
circuitv2: clarify what to do when data limit is reached

### DIFF
--- a/relay/circuit-v2.md
+++ b/relay/circuit-v2.md
@@ -259,7 +259,7 @@ If more data than the limit specified in the `data` field is transferred
 over the connection, the server should reset the stream. If the reservation
 for the connection has expired the server may then apply any connection
 management policy to the connection as normal otherwise it should retain
-the connection, unless doing so would prevent it from mainting it's resource
+the connection, unless doing so would prevent it from maintaining it's resource
 quotas.
 
 ***Note: Implementations _should not_ accept reservations over already relayed connections.***

--- a/relay/circuit-v2.md
+++ b/relay/circuit-v2.md
@@ -4,7 +4,7 @@ This is the version 2 of the libp2p Circuit Relay protocol.
 
 | Lifecycle Stage | Maturity       | Status | Latest Revision |
 | --------------- | -------------- | ------ | --------------- |
-| 3A              | Recommendation | Active | r2, 2023-01-31  |
+| 3A              | Recommendation | Active | r3, 2023-02-28  |
 
 Authors: [@vyzo]
 

--- a/relay/circuit-v2.md
+++ b/relay/circuit-v2.md
@@ -256,7 +256,7 @@ If a relay server becomes overloaded however, it may still drop a
 connection with reservations in order to maintain its resource quotas.
   
 If more data than the limit specified in the `data` field is transferred
-over the connection, the server should reset the stream. If the reservation
+over the relayed connection, or the relayed connection has been open for longer than `duration`, the relay should reset the stream to the source and the stream to the destination. If the reservation
 for the connection has expired the server may then apply any connection
 management policy to the connection as normal otherwise it should retain
 the connection, unless doing so would prevent it from maintaining its resource

--- a/relay/circuit-v2.md
+++ b/relay/circuit-v2.md
@@ -254,13 +254,16 @@ connection for the duration of any reservations and tag it to prevent
 accidental termination according to its connection management policy.
 If a relay server becomes overloaded however, it may still drop a
 connection with reservations in order to maintain its resource quotas.
-  
+
 If more data than the limit specified in the `data` field is transferred
-over the relayed connection, or the relayed connection has been open for longer than `duration`, the relay should reset the stream to the source and the stream to the destination. If the reservation
-for the connection has expired the server may then apply any connection
-management policy to the connection as normal otherwise it should retain
-the connection, unless doing so would prevent it from maintaining its resource
-quotas.
+over the relayed connection, or the relayed connection has been open for
+longer than `duration`, the relay should reset the stream to the source
+and the stream to the destination.
+
+If the reservation for the connection has expired then the relay may
+apply any connection management policy to the connection as normal otherwise
+it should retain the connection, unless doing so would prevent it from
+maintaining its resource quotas.
 
 ***Note: Implementations _should not_ accept reservations over already relayed connections.***
 

--- a/relay/circuit-v2.md
+++ b/relay/circuit-v2.md
@@ -254,6 +254,13 @@ connection for the duration of any reservations and tag it to prevent
 accidental termination according to its connection management policy.
 If a relay server becomes overloaded however, it may still drop a
 connection with reservations in order to maintain its resource quotas.
+  
+If more data than the limit specified in the `data` field is transferred
+over the connection, the server should reset the stream. If the reservation
+for the connection has expired the server may then apply any connection
+management policy to the connection as normal otherwise it should retain
+the connection, unless doing so would prevent it from mainting it's resource
+quotas.
 
 ***Note: Implementations _should not_ accept reservations over already relayed connections.***
 

--- a/relay/circuit-v2.md
+++ b/relay/circuit-v2.md
@@ -259,7 +259,7 @@ If more data than the limit specified in the `data` field is transferred
 over the connection, the server should reset the stream. If the reservation
 for the connection has expired the server may then apply any connection
 management policy to the connection as normal otherwise it should retain
-the connection, unless doing so would prevent it from maintaining it's resource
+the connection, unless doing so would prevent it from maintaining its resource
 quotas.
 
 ***Note: Implementations _should not_ accept reservations over already relayed connections.***


### PR DESCRIPTION
This documents the rust-libp2p behaviour when more data than is allowed is transferred over a relayed connection.  js-libp2p will take the same approach.  go-libp2p may need to be updated.