### PR TITLE
http: use .well-known/libp2p.json for configuration

### DIFF
--- a/http/README.md
+++ b/http/README.md
@@ -47,8 +47,10 @@ The document contains a mapping of protocols to their respective URL. For exampl
 
 ```json
 {
-  "/kad/1.0.0": "/kademlia/",
-  "server-auth": "/libp2p/server-auth"
+  "services": {
+    "/kad/1.0.0": "/kademlia/",
+    "server-auth": "/libp2p/server-auth"
+  }
 }
 ```
 


### PR DESCRIPTION
This is slightly different from what I presented in the Moves The Bytes WG yesterday.
I introduced a `"services"` dict entry in the JSON object. This will allow us to add more configuration to the `libp2p.json` in the future (and not just protocol => path mapping).