### PR TITLE
circuitv2: specify timestamp units for reservation expiration

### DIFF
--- a/relay/circuit-v2.md
+++ b/relay/circuit-v2.md
@@ -224,7 +224,7 @@ Reservation {
 }
 ```
 
-- the `expire` field contains the expiration time as a UTC UNIX time. The reservation becomes invalid after this time and it's the responsibility of the client to refresh.
+- the `expire` field contains the expiration time as a UTC UNIX time in seconds. The reservation becomes invalid after this time and it's the responsibility of the client to refresh.
 - the `addrs` field contains all the public relay addrs, including the peer ID of the relay node but not the
   trailing `p2p-circuit` part; the client can use this list to construct its
   own `p2p-circuit` relay addrs for advertising by encapsulating


### PR DESCRIPTION
The reservation expiration date is specified in seconds so be explicit about that in the spec in the same way we are explicit about the duration limit units.