### PR TITLE
chore(roadmap): move webrtc to done

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -648,7 +648,7 @@ connect to the rest of the libp2p network.
 
 ### WebRTC
 
-**Status**: In progress
+**Status**: Done
 
 **What?** WebRTC is a transport protocol supported by all major browsers. Those
 browsers allow the establishment of connections to remote endpoints that don't

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,7 +23,6 @@ third-party data ownership.
   - [⏱ Full Observability](#-full-observability)
   - [🧪 Automated compatibility testing](#-automated-compatibility-testing)
   - [Stream Migration Protocol](#stream-migration-protocol)
-  - [WebRTC](#webrtc)
   - [🤖 libp2p as a Wasm library](#-libp2p-as-a-wasm-library)
   - [🤝 Low latency, efficient connection handshake](#-low-latency-efficient-connection-handshake)
   - [🛣️ Peer Routing Records](#️-peer-routing-records)
@@ -38,6 +37,7 @@ third-party data ownership.
   - [🏹 RPC and other common node communication patterns](#-rpc-and-other-common-node-communication-patterns)
 - [Done](#done)
   - [🕸 Hole punching on TCP and QUIC](#-hole-punching-on-tcp-and-quic)
+  - [WebRTC](#webrtc)
 
 ## Core Tenets
 Before we dive into what libp2p should support and enable, let's outline the core tenets that underpin the project. As maintainers, we commit to ensuring libp2p is:
@@ -264,27 +264,6 @@ connection to a direct connection.
 
 - Tracking issue https://github.com/libp2p/specs/issues/328
 - Specification draft https://github.com/libp2p/specs/pull/406#discussion_r852835671
-
-### WebRTC
-
-**Status**: In progress
-
-**What?** WebRTC is a transport protocol supported by all major browsers. Those
-browsers allow the establishment of connections to remote endpoints that don't
-have a TLS certificate signed by a trusted certificate authority. In addition
-WebRTC includes hole punching capabilities.
-
-**Why?** In most p2p networks the majority of nodes do not have a signed TLS
-certificate. With WebRTC browsers will thus be able to connect to these
-previously unreachable nodes. In addition, being able to hole punch allows
-browsers to connect to nodes behind firewalls and NATs e.g. other browsers. Note
-that the former, namely connecting without trusted TLS certificate, can as well
-be achieved with the [WebTransport](#✈️-webtransport) protocol.
-
-**Links:**
-
-- Tracking issue https://github.com/libp2p/specs/issues/220
-- Specification draft https://github.com/libp2p/specs/pull/412
 
 ### 🤖 libp2p as a Wasm library
 
@@ -666,3 +645,25 @@ connect to the rest of the libp2p network.
 - [webtransport-go](https://github.com/marten-seemann/webtransport-go/)
 - [go-libp2p WebTransport](https://github.com/libp2p/go-libp2p/tree/master/p2p/transport/webtransport)
 - [js-libp2p WebTransport](https://github.com/libp2p/js-libp2p-webtransport/)
+
+### WebRTC
+
+**Status**: In progress
+
+**What?** WebRTC is a transport protocol supported by all major browsers. Those
+browsers allow the establishment of connections to remote endpoints that don't
+have a TLS certificate signed by a trusted certificate authority. In addition
+WebRTC includes hole punching capabilities.
+
+**Why?** In most p2p networks the majority of nodes do not have a signed TLS
+certificate. With WebRTC browsers will thus be able to connect to these
+previously unreachable nodes. In addition, being able to hole punch allows
+browsers to connect to nodes behind firewalls and NATs e.g. other browsers. Note
+that the former, namely connecting without trusted TLS certificate, can as well
+be achieved with the [WebTransport](#✈️-webtransport) protocol.
+
+**Links:**
+
+- Tracking issue https://github.com/libp2p/specs/issues/220
+- [`/webrtc` specification](./webrtc/webrtc.md)
+- [`/webrtc-direct` specification](./webrtc/webrtc-direct.md)


### PR DESCRIPTION
With https://github.com/libp2p/specs/pull/412 and
https://github.com/libp2p/specs/pull/497 merged, this roadmap item can be moved to "done".