### PR TITLE
fix(mdns): require loopback addresses to be ignored

### DIFF
--- a/discovery/mdns.md
+++ b/discovery/mdns.md
@@ -120,7 +120,7 @@ Many existing tools ignore the Additional Records, and always send individual qu
 
 ## Issues
 
-[ ] mDNS requires link-local addresses. Loopback and "NAT busting" addresses should not sent and must be ignored on receipt?
+mDNS requires link-local addresses. Loopback and "NAT busting" addresses should not sent and must be ignored on receipt.
 
 ## References
 


### PR DESCRIPTION
We should also only be sending link-local addresses in mDNS responses but the wording here seems to suggest this is an open ended question.