### PR TITLE
webrtc: add FIN_ACK to close datachannels without data loss

### DIFF
--- a/webrtc/README.md
+++ b/webrtc/README.md
@@ -174,8 +174,7 @@ to the user. Consequently we must add an additional layer of signaling to ensure
 reliable data delivery.
 
 When a node wishes to close a stream for writing, it SHOULD send a message with
-the `FIN` flag set, then proceed to wait for a `FIN_ACK` message from the remote
-node.
+the `FIN` flag set. A node SHOULD only consider its write-half closed once it received a `FIN_ACK`.
 
 If a `FIN` flag is received the node SHOULD respond with a `FIN_ACK`.
 
@@ -183,7 +182,7 @@ When a `FIN_ACK` and a `FIN` have been received, a node may close the datachanne
 
 The node MAY close the datachannel without receiving a `FIN_ACK`, for example in
 the case of a timeout, but there will be no guarantee that all previously sent
-messages have been received.
+messages have been received by the remote.
 
 If a node has previously sent a `STOP_SENDING` flag to the remote node, it MUST
 continue to act on any flags present in received messages in order to
@@ -196,16 +195,16 @@ finishes writing.
 
 ```mermaid
 sequenceDiagram
-    NodeA->>NodeB: DATA
-    NodeA->>NodeB: FIN
-    NodeB->>NodeA: FIN_ACK
-    NodeB->>NodeA: DATA
-    NodeB->>NodeA: FIN
-    NodeA->>NodeB: FIN_ACK
+    A->>B: DATA
+    A->>B: FIN
+    B->>A: FIN_ACK
+    B->>A: DATA
+    B->>A: FIN
+    A->>B: FIN_ACK
 ```
 
-After NodeA has received the `FIN` it is free to close the datachannel since it
-has previously received a `FIN_ACK`. If NodeB receives the `FIN_ACK` before this
+After _A_ has received the `FIN` it is free to close the datachannel since it
+has previously received a `FIN_ACK`. If _B_ receives the `FIN_ACK` before this
 it may close the channel since it previously received a `FIN`.
 
 This way the channel can be closed from either end without data loss.

--- a/webrtc/README.md
+++ b/webrtc/README.md
@@ -174,9 +174,11 @@ to the user. Consequently we must add an additional layer of signaling to ensure
 reliable data delivery.
 
 When a node wishes to close a stream for writing, it SHOULD send a message with
-the `FIN` flag set. A node SHOULD only consider its write-half closed once it received a `FIN_ACK`.
+the `FIN` flag set.
 
 If a `FIN` flag is received the node SHOULD respond with a `FIN_ACK`.
+
+A node SHOULD only consider its write-half closed once it received a `FIN_ACK`.
 
 When a `FIN_ACK` and a `FIN` have been received, a node may close the datachannel.
 

--- a/webrtc/README.md
+++ b/webrtc/README.md
@@ -170,17 +170,19 @@ of the `RTCDataChannel` `label` property.
 Some WebRTC implementations do not guarantee that any queued messages will be
 sent after a datachannel is closed.  Other implementations maintain separate
 outgoing message and transport queues, the status of which may not be visible
-to the user. Consequently we must add an additional layer of signaling to ensure
-reliable data delivery.
+to the user. Consequently we must add an additional layer of signaling to
+ensure reliable data delivery.
 
 When a node wishes to close a stream for writing, it MUST send a message with
 the `FIN` flag set.
 
 If a `FIN` flag is received the node SHOULD respond with a `FIN_ACK`.
 
-A node SHOULD only consider its write-half closed once it has received a `FIN_ACK`.
+A node SHOULD only consider its write-half closed once it has received a
+`FIN_ACK`.
 
-When a `FIN_ACK` and a `FIN` have been received, the node may close the datachannel.
+When a `FIN_ACK` and a `FIN` have been received, the node may close the
+datachannel.
 
 The node MAY close the datachannel without receiving a `FIN_ACK`, for example in
 the case of a timeout, but there will be no guarantee that all previously sent
@@ -192,8 +194,8 @@ successfully process an incoming `FIN_ACK`.
 
 ### Example of closing an `RTCDataChannel`
 
-NodeA closes for writing, NodeB delays allowing the channel to close until it also
-finishes writing.
+NodeA closes for writing, NodeB delays allowing the channel to close until it
+also finishes writing.
 
 ```mermaid
 sequenceDiagram

--- a/webrtc/README.md
+++ b/webrtc/README.md
@@ -67,6 +67,10 @@ message Message {
     // The sender abruptly terminates the sending part of the stream. The
     // receiver MAY discard any data that it already received on that stream.
     RESET_STREAM = 2;
+    // The receiver has previously sent a message with a FIN flag. On receiving
+    // this flag they may now close the stream as they know the remote has received
+    // all data that was sent.
+    FIN_ACK = 3;
   }
 
   optional Flag flag=1;
@@ -132,8 +136,8 @@ real-world experiments.
 
 `RTCDataChannel`s are negotiated in-band by the WebRTC user agent (e.g. Firefox,
 Pion, ...). In other words libp2p WebRTC implementations MUST NOT change the
-default value `negotiated: false` when creating a standard libp2p stream 
-of type `RTCDataChannel` via `RTCPeerConnection.createDataChannel`. 
+default value `negotiated: false` when creating a standard libp2p stream
+of type `RTCDataChannel` via `RTCPeerConnection.createDataChannel`.
 Setting `negotiated: true` is reserved only for creating Noise handshake channels
 under certain protocol conditions.
 
@@ -160,6 +164,50 @@ MUST pass an empty string. When receiving an `RTCDataChannel` via
 `RTCPeerConnection.ondatachannel` implementations MUST NOT require `label` to be
 an empty string. This allows future versions of this specification to make use
 of the `RTCDataChannel` `label` property.
+
+## Closing an `RTCDataChannel`
+
+Some WebRTC implementations do not guarantee that any queued messages will be
+sent after a datachannel is closed.  Other implementatations maintain separate
+outgoing message and transport queues, the status of which may not be visible
+to the user. Consequently we must add an additional layer of signaling to ensure
+reliable data delivery.
+
+When a node wishes to close a stream for writing, it should send a message with
+the `FIN` flag set, then proceed to wait for a `FIN_ACK` message from the remote
+node.
+
+If a `FIN` flag is received and the node has finished writing data, it should
+respond with a `FIN_ACK` immediately.
+
+If a `FIN` flag is recieved but the node has not finished writing data, it should
+delay sending a `FIN_ACK` response until it has finished writing data, sent a
+`FIN` flag, and finally received a `FIN_ACK` in response.
+
+When a `FIN_ACK` has been sent and received, a node may close the datachannel.
+
+The node may close the datachannel without receiving a `FIN_ACK`, for example in
+the case of a timeout, but there will be no guarantee that all previously sent
+messages have been received.
+
+If a node has previously sent a `STOP_SENDING` flag to the remote node, it must
+continue to act on any flags present in received messages in order to
+successfully process an incoming `FIN_ACK`.
+
+### Example of closing an `RTCDataChannel`
+
+NodeA closes for writing, NodeB delays allowing the channel to close until it also
+finishes writing.
+
+```mermaid
+sequenceDiagram
+    NodeA->>NodeB: DATA
+    NodeA->>NodeB: FIN
+    NodeB->>NodeA: DATA
+    NodeB->>NodeA: FIN
+    NodeA->>NodeB: FIN_ACK
+    NodeB->>NodeA: FIN_ACK
+```
 
 ## Previous, ongoing and related work
 

--- a/webrtc/README.md
+++ b/webrtc/README.md
@@ -68,8 +68,8 @@ message Message {
     // receiver MAY discard any data that it already received on that stream.
     RESET_STREAM = 2;
     // The receiver has previously sent a message with a FIN flag. On receiving
-    // this flag they may now close the stream as they know the remote has received
-    // all data that was sent.
+    // the FIN_ACK flag they may now close the stream as they know the remote has received
+    // all data that was sent before the FIN.
     FIN_ACK = 3;
   }
 
@@ -173,24 +173,24 @@ outgoing message and transport queues, the status of which may not be visible
 to the user. Consequently we must add an additional layer of signaling to ensure
 reliable data delivery.
 
-When a node wishes to close a stream for writing, it should send a message with
+When a node wishes to close a stream for writing, it SHOULD send a message with
 the `FIN` flag set, then proceed to wait for a `FIN_ACK` message from the remote
 node.
 
-If a `FIN` flag is received and the node has finished writing data, it should
+If a `FIN` flag is received and the node has finished writing data, it SHOULD
 respond with a `FIN_ACK` immediately.
 
-If a `FIN` flag is recieved but the node has not finished writing data, it should
+If a `FIN` flag is received but the node has not finished writing data, it SHOULD
 delay sending a `FIN_ACK` response until it has finished writing data, sent a
 `FIN` flag, and finally received a `FIN_ACK` in response.
 
 When a `FIN_ACK` has been sent and received, a node may close the datachannel.
 
-The node may close the datachannel without receiving a `FIN_ACK`, for example in
+The node MAY close the datachannel without receiving a `FIN_ACK`, for example in
 the case of a timeout, but there will be no guarantee that all previously sent
 messages have been received.
 
-If a node has previously sent a `STOP_SENDING` flag to the remote node, it must
+If a node has previously sent a `STOP_SENDING` flag to the remote node, it MUST
 continue to act on any flags present in received messages in order to
 successfully process an incoming `FIN_ACK`.
 

--- a/webrtc/README.md
+++ b/webrtc/README.md
@@ -173,14 +173,14 @@ outgoing message and transport queues, the status of which may not be visible
 to the user. Consequently we must add an additional layer of signaling to ensure
 reliable data delivery.
 
-When a node wishes to close a stream for writing, it SHOULD send a message with
+When a node wishes to close a stream for writing, it MUST send a message with
 the `FIN` flag set.
 
 If a `FIN` flag is received the node SHOULD respond with a `FIN_ACK`.
 
-A node SHOULD only consider its write-half closed once it received a `FIN_ACK`.
+A node SHOULD only consider its write-half closed once it has received a `FIN_ACK`.
 
-When a `FIN_ACK` and a `FIN` have been received, a node may close the datachannel.
+When a `FIN_ACK` and a `FIN` have been received, the node may close the datachannel.
 
 The node MAY close the datachannel without receiving a `FIN_ACK`, for example in
 the case of a timeout, but there will be no guarantee that all previously sent


### PR DESCRIPTION
Specify closing datachannels by mutual agreement to ensure all data has been received by the remote before closing.

Refs: #575