### PR TITLE
identify: clarify that `listenAddrs` should be external addresses

### DIFF
--- a/identify/README.md
+++ b/identify/README.md
@@ -109,7 +109,9 @@ in [peer-ids](../peer-ids).
 
 ### listenAddrs
 
-These are the addresses on which the peer is listening as multi-addresses.
+The addresses on which the peer is deemed to be reachable by other peers.
+These are also sometimes referred to as _external_ addresses.
+For backwards-compatibility reasons, implementations MAY also include addresses of local interfaces.
 
 ### observedAddr
 


### PR DESCRIPTION
When taken literally, the spec currently demands to include the listen addresses in this field.  That is pretty useless unless the node is listening on an interface that is directly connected to the public Internet.

In most cases, a node will be behind NAT which might have port-forwarding configured to be externally reachable. In either case, the local listening addresses are not going to help other peers in connecting.

Please consider this change in isolation of other PRs / issues around the identify spec. Ideally, the entire spec would be overhauled because it e.g. doesn't mention peer records (also see #347). However, not all implementations support peer records in identify and effort on extending the spec has stalled due to various issues.

It would be great if we could just clarify this one element in isolation without opening the can of worms that the spec overhaul is. Thank you!

cc interest group: @vyzo @yusefnapora @tomaka @richardschneider @Stebalien @bigs 

Related: https://github.com/libp2p/rust-libp2p/issues/4010.