### PR TITLE
webrtc: introduce versioning for signalling protocol id

### DIFF
--- a/webrtc/webrtc.md
+++ b/webrtc/webrtc.md
@@ -21,7 +21,7 @@ On a historical note, this specification replaces the existing [libp2p WebRTC st
 
 1. _B_ advertises support for the WebRTC browser-to-browser protocol by appending `/webrtc` to its relayed multiaddr, meaning it takes the form of `<relayed-multiaddr>/webrtc/p2p/<b-peer-id>`.
 
-2. Upon discovery of _B_'s multiaddress, _A_ learns that _B_ supports the WebRTC transport and knows how to establish a relayed connection to _B_ to run the `/webrtc-signaling` protocol on top.
+2. Upon discovery of _B_'s multiaddress, _A_ learns that _B_ supports the WebRTC transport and knows how to establish a relayed connection to _B_ to run the `/webrtc-signaling/0.0.1` protocol on top.
 
 3. _A_ establishes a relayed connection to _B_.
    Note that further steps depend on the relayed connection to be authenticated, i.e. that data sent on the relayed connection can be trusted.
@@ -68,7 +68,7 @@ It is not necessary for _A_ and _B_ to use the same STUN server when establishin
 
 ## Signaling Protocol
 
-The protocol id is `/webrtc-signaling`.
+The protocol id is `/webrtc-signaling/0.0.1`.
 Messages are sent prefixed with the message length in bytes, encoded as an unsigned variable length integer as defined by the [multiformats unsigned-varint spec][uvarint-spec].
 
 ``` protobuf


### PR DESCRIPTION
The js-libp2p implementation of webrtc includes versioning for the [signalling protocol id](https://github.com/libp2p/js-libp2p/blob/9c67c5b3d0ab63c7a1a62f363ae732b300ef6b87/packages/transport-webrtc/src/private-to-private/transport.ts#L25) therefore existing nodes that support private-to-private would be utilizing a versioned protocol id. Whilst this may have been a mistake, it could be more prudent to introduce this versioning at the spec level as opposed to forcing existing nodes to synchronize upgrades.

1) There is already a precedent for versioning protocol ids across a variety of the protocols
2) The added benefit of future-proofing this protocol.

There is also the argument that we would be adjusting the spec in order to adapt to an implementation mistake, in most cases I would agree here but I think this is a more innocuous change than other situations.

Related:

https://github.com/libp2p/js-libp2p/issues/2238
https://github.com/libp2p/js-libp2p/pull/2239