### PR TITLE
muxer: correct inline muxer negotiation choice

### DIFF
--- a/connections/inlined-muxer-negotiation.md
+++ b/connections/inlined-muxer-negotiation.md
@@ -90,7 +90,7 @@ XX:
 -> s, se, [ "/yamux/1.0.0", "/mplex/6.7.0" ] 
 ```
 
-The result of this negotiation is `"/mplex/6.7.0"`.
+The result of this negotiation is `"/yamux/1.0.0"`.
 
 If there is no overlap between the multiplexers support by client and server,
 the handshake MUST fail.


### PR DESCRIPTION
Based on this
```
The multiplexer to use is determined by picking the first item from the initiator's list that both parties support.
```
The chosen multiplexer to use will be `yamux/1.0.0`