### PR TITLE
kad: improve FIND_NODE response definition

### DIFF
--- a/kad-dht/README.md
+++ b/kad-dht/README.md
@@ -2,11 +2,11 @@
 
 | Lifecycle Stage | Maturity       | Status | Latest Revision |
 |-----------------|----------------|--------|-----------------|
-| 3A              | Recommendation | Active | r2, 2022-12-09  |
+| 3A              | Recommendation | Active | r3, 2024-03-27  |
 
 Authors: [@raulk], [@jhiesey], [@mxinden]
 
-Interest Group:
+Interest Group: [@guillaumemichel]
 
 [@raulk]: https://github.com/raulk
 [@jhiesey]: https://github.com/jhiesey
@@ -163,7 +163,8 @@ Then we loop:
 3. Upon a response:
 	1. If successful the response will contain the `k` closest nodes the peer
        knows to the key `Key`. Add them to the candidate list `Pn`, except for
-       those that have already been queried.
+       those that have already been queried. The response should never include 
+       the responder's own peer record nor the peer record of the requester.
 	2. If an error or timeout occurs, discard it.
 4. Go to 1.
 


### PR DESCRIPTION
## Context

The [Kademlia spec](https://github.com/libp2p/specs/blob/master/kad-dht/README.md) doesn't explicitly define how a node `N` should answer to the request `FIND_NODE(N)`. The `FIND_NODE` RPC is expected to return the (`k`) closest nodes to the requested key. 

> The libp2p Kademlia DHT offers the following types of operations:
> * Peer routing
>     * Finding the closest nodes to a given key via FIND_NODE.

> 3. Upon a response:
>     1. If successful the response will contain the k closest nodes the peer knows to the key Key. Add them to the candidate list Pn, except for those that have already been queried.

Implementations have diverse behaviors and expectations, which can lead to poor interoperability (see https://github.com/libp2p/go-libp2p-kad-dht/issues/966).

* [go-libp2p-kad-dht](https://github.com/libp2p/go-libp2p-kad-dht) only returns [its own peer record](https://github.com/libp2p/go-libp2p-kad-dht/blob/1b5d0b69ec72752f651145f9f3a8aded499ab454/handlers.go#L265-L266).
* [rust-libp2p](https://github.com/libp2p/rust-libp2p) sends an [empty response](https://github.com/libp2p/rust-libp2p/blob/a579e691c46a8efd2e38ebafca1c59a9b58fc56c/protocols/kad/src/behaviour.rs#L1183-L1184).
* [js-libp2p](https://github.com/libp2p/js-libp2p) only returns [its own peer record](https://github.com/libp2p/js-libp2p/blob/d12cdce8e58012a1f01cb06c4fcc7adec1c1818f/packages/kad-dht/src/rpc/handlers/find-node.ts#L53-L57).

None of these implementations actually follows the spec, so they should be adapted to return the `k` closest peers.

## Proposal

1. **Nodes should not return their own peer record if they are among the `k` known closest peers to the requested key.**
    * Peers sending the request `FIND_NODE(N)` to `N` already have `N`'s peer record. Even though the peer record sent by `N` could include additional multiaddresses that the requestor isn't aware of yet, this is the role of `Identify`, not the DHT.
2. **`FIND_NODE` response should never include the requester among the _closer peers_.**
    * This information is useless.