### PR TITLE
yamux: add error codes on stream reset

### DIFF
--- a/yamux/README.md
+++ b/yamux/README.md
@@ -128,7 +128,7 @@ This does a half-close indicating the sender will send no further data.
 
 Once both sides have closed the connection, the stream is closed.
 
-Alternatively, if an error occurs, the RST flag can be used to hard close a stream immediately.
+Alternatively, if an error occurs, the RST flag can be used to hard close a stream immediately. To provide an error on stream resets, the first four bytes of the data following the header can contain a bigendian 32bit unsigned integer error code. Implementations should discard any data following the 4 bytes of error code. 
 
 #### Flow Control
 


### PR DESCRIPTION
Required for #479 

As I understand, all the implementations discard the data when receiving a frame with the `RST` flag set. 
@MarcoPolo @achingbrain can you confirm this for rust-yamux and js-yamux. I think this is what both the implementations are doing.

We send the error code as a 4byte integer following the header. We cannot use the length field like in a goaway frame, because all the implementations look at the length field and read length bytes of data even with the RST flag set.

