### PR TITLE
docs(websockets): include explicit /sni/ example

### DIFF
--- a/websockets/README.md
+++ b/websockets/README.md
@@ -62,6 +62,7 @@ Examples:
 
 * `/ip4/192.0.2.0/tcp/1234/ws` (an insecure address with a TCP port)
 * `/ip4/192.0.2.0/tcp/1234/tls/ws` (a secure address with a TCP port)
+* `/ip4/192.0.2.0/tcp/1234/tls/sni/foo.example.com/ws` (a secure address with resolved DNS address with explicit SNI value for TLS)
 * `/ip4/192.0.2.0/ws` (an insecure address that defaults to TCP port 80)
 * `/ip4/192.0.2.0/tls/ws` (a secure address that defaults to TCP port 443)
 * `/ip4/192.0.2.0/wss` (`/tls` may be omitted when using `/wss`)


### PR DESCRIPTION
The spec is missing example with `/sni/` which is how every `libp2p.direct` from [AutoTLS in Kubo >=0.32.0-rc1](https://github.com/ipfs/kubo/issues/10560) will look like. 

This PR adds it.