### PR TITLE
[GossipSub 1.2] Allow sending IDONTWANTs when publishing

### DIFF
--- a/pubsub/gossipsub/gossipsub-v1.2.md
+++ b/pubsub/gossipsub/gossipsub-v1.2.md
@@ -56,6 +56,7 @@ This section lists the configuration parameters that needs to agreed on across c
 When the peer receives the first message instance it immediately broadcasts 
 (not queue for later piggybacking) `IDONTWANT` with the `messageId` to all its mesh peers. 
 This could be performed prior to the message validation to further increase the effectiveness of the approach.    
+Additionally, on networks where multiple messages share the same messageId, a user may choose to broadcast IDONTWANT when publishing.
 
 On the other side a node maintains per-peer `dont_send_message_ids` set. Upon receiving `IDONTWANT` from 
 a peer the `messageId` is added to the `dont_send_message_ids` set. 


### PR DESCRIPTION
With the introduction of  [`getBlobsV1`](https://github.com/ethereum/execution-apis/blob/4140e528360fea53c34a766d86a000c6c039100e/src/engine/cancun.md#engine_getblobsv1) for the Cancun upgrade in the Ethereum network, nodes may publish blobs (messages) retrieved from the Execution Layer without receiving them through Gossipsub. In such cases, a node already has the blobs and can conserve download bandwidth by sending out IDONTWANT messages to peers for the blobs it publishes. This prevents the node from receiving the same blobs again through gossip.
This PR aims to clarify the behavior at the specification level.
See more [here](https://github.com/sigp/lighthouse/pull/6513)

Thanks!