### PR TITLE
docs: clarify FIND_NODE response for DHT-client nodes

### DIFF
--- a/kad-dht/README.md
+++ b/kad-dht/README.md
@@ -490,7 +490,9 @@ These are the requirements for each `MessageType`:
 
 * `FIND_NODE`: In the request `key` must be set to the binary `PeerId` of the
   node to be found. In the response `closerPeers` is set to the `k` closest
-  `Peer`s.
+  `Peer`s.  Each closer peer will be a DHT server, unless `key` is an exact for
+  a peer known to the node, in which case the closer peers will include the
+  matching, non-server peer.
 
 * `GET_VALUE`: In the request `key` is an unstructured array of bytes. `record`
   is set to the value for the given key (if found in the datastore) and


### PR DESCRIPTION
If a node receives a `FIND_NODE` RPC call with a peer ID, it should return only closer DHT servers, unless it knows the peer ID in question, in which case it should include it, even if it is not a DHT server.