### PR TITLE
Add gossipsub 1.2 links to the README

### DIFF
--- a/pubsub/gossipsub/README.md
+++ b/pubsub/gossipsub/README.md
@@ -16,20 +16,21 @@ If you are new to Gossipsub and/or PubSub in general, we recommend you to first:
 
 - [gossipsub-v1.0](gossipsub-v1.0.md): v1.0 of the gossipsub protocol. This is a revised specification, to use a more normative language. The original v1.0 specification is [here](gossipsub-v1.0-old.md), still a good read.
 - [gossipsub-v1.1](gossipsub-v1.1.md): v1.1 of the gossipsub protocol.
+- [gossipsub-v1.2](gossipsub-v1.2.md): v1.2 of the gossipsub protocol. This includes the aggregation of the IDONTWANT control messages to the specs.
 - [(not in use) episub](episub.md): a research note on a protocol building on top of gossipsub to implement [epidemic broadcast trees](https://www.gsd.inesc-id.pt/~ler/reports/srds07.pdf).
 
 ## Implementation status
 
 Legend: ✅ = complete, 🏗 = in progress, ❕ = not started yet
 
-| Name                                                                                             | v1.0  | v1.1  |
-|--------------------------------------------------------------------------------------------------|:-----:|:-----:|
-| [go-libp2p-pubsub (Golang)](https://github.com/libp2p/go-libp2p-pubsub/blob/master/gossipsub.go) |   ✅  |   ✅  |
-| [js-libp2p-gossipsub (JavaScript)](https://github.com/ChainSafe/js-libp2p-gossipsub)                    |   ✅  |   ✅  |
-| [rust-libp2p (Rust)](https://github.com/libp2p/rust-libp2p/tree/master/protocols/gossipsub)      |   ✅ |   ✅  |
-| [py-libp2p (Python)](https://github.com/libp2p/py-libp2p/tree/master/libp2p/pubsub)              |   ✅  |   🏗  |
-| [jvm-libp2p (Java/Kotlin)](https://github.com/libp2p/jvm-libp2p/tree/develop/src/main/kotlin/io/libp2p/pubsub) |   ✅  |   🏗  |
-| [nim-libp2p (Nim)](https://github.com/status-im/nim-libp2p/blob/master/libp2p/protocols/pubsub/gossipsub.nim) |   ✅  |   🏗  |
+| Name                                                                                             | v1.0  | v1.1  | v1.2 |
+|--------------------------------------------------------------------------------------------------|:-----:|:-----:|:----:|
+| [go-libp2p-pubsub (Golang)](https://github.com/libp2p/go-libp2p-pubsub/blob/master/gossipsub.go) |   ✅  |   ✅  |   ✅  | 
+| [js-libp2p-gossipsub (JavaScript)](https://github.com/ChainSafe/js-libp2p-gossipsub)             |   ✅  |   ✅  |   ✅  |
+| [rust-libp2p (Rust)](https://github.com/libp2p/rust-libp2p/tree/master/protocols/gossipsub)      |   ✅  |   ✅  |  ❔   |
+| [py-libp2p (Python)](https://github.com/libp2p/py-libp2p/tree/master/libp2p/pubsub)              |   ✅  |   🏗  |   ❔  |
+| [jvm-libp2p (Java/Kotlin)](https://github.com/libp2p/jvm-libp2p/tree/develop/src/main/kotlin/io/libp2p/pubsub) |   ✅  |   🏗  |   ✅  |
+| [nim-libp2p (Nim)](https://github.com/status-im/nim-libp2p/blob/master/libp2p/protocols/pubsub/gossipsub.nim) |   ✅  |   🏗  |   ✅  |
 
 Additional tooling:
 


### PR DESCRIPTION
# Description
I've noticed that despite GossipSub 1.2 spec being merged to the specs-repo, it is not present in the summary of the README file. This PR update the summary with the current status of the development.

Open questions:
- I'm aware that the Sigp had IDONTWANT implemented in Lighthouse's rust-libp2p, but I couldn't find any link in the `rust-libp2p` repo. Leaving the question mark on `rust-libp2p` until @AgeManning or @jxs  can confirm the status. 

CC: @vyzo 
