### PR TITLE
kad: clarify bootstrap process

### DIFF
--- a/kad-dht/README.md
+++ b/kad-dht/README.md
@@ -368,14 +368,13 @@ the wire format and keep their routing table up-to-date, especially with peers
 closest to themselves.
 
 The process runs once on startup, then periodically with a configurable
-frequency (default: 5 minutes). On every run, we generate a random peer ID and
-we look it up via the process defined in [peer routing](#peer-routing). Peers
-encountered throughout the search are inserted in the routing table, as per
-usual business.
+frequency (default: 10 minutes). On every run, we generate a random peer ID for
+every non-empty routing table's k-bucket and we look it up via the process
+defined in [peer routing](#peer-routing). Peers encountered throughout the
+search are inserted in the routing table, as per usual business.
 
-This is repeated as many times per run as configuration parameter `QueryCount`
-(default: 1). In addition, to improve awareness of nodes close to oneself,
-implementations should include a lookup for their own peer ID.
+In addition, to improve awareness of nodes close to oneself, implementations
+should include a lookup for their own peer ID.
 
 Every repetition is subject to a `QueryTimeout` (default: 10 seconds), which
 upon firing, aborts the run.


### PR DESCRIPTION
* Note that the bootstrap process description is [just a suggestion](https://github.com/libp2p/specs/blob/b5f7fce29b32d4c7d0efe37b019936a11e5db872/kad-dht/README.md?plain=1#L365-L368)
> The below is one possible algorithm to bootstrap. Implementations may diverge from this base algorithm as long as they adhere to the wire format and keep their routing table up-to-date, especially with peers
closest to themselves.
* Update default bootstrap interval to 10 minutes ([go-libp2p-kad-dht](https://github.com/libp2p/go-libp2p-kad-dht/blob/88720a04b40153855cf8d5e27e8a4a6bddb3092a/internal/config/config.go#L126), [IPFS doc](https://docs.ipfs.tech/concepts/dht/#routing-tables))
* Replace _a random peer ID_ with _a random peer ID for every non-empty routing table's k-bucket_.
  * The random peer ID has a very low probability to land in a bucket close to the node, hence the close buckets (with a high bucket ID), will (statistically) never be refreshed.
  * Taking a random peer ID falling in every non-empty k-bucket makes sure to refresh all populated buckets.
* Remove the mention of `QueryCount` since it isn't mentioned anywhere else in the document, and it isn't necessary to perform this operation multiple times since all buckets are refreshed by the described process.

cc: @stormshield-frb