### PR TITLE
fix: http auth header typo

### DIFF
--- a/http/peer-id-auth.md
+++ b/http/peer-id-auth.md
@@ -169,7 +169,7 @@ protocol operates as follows:
    headers:
 
    ```
-   Authentication-Info: libp2p-PeerID, sig="<base64-signature-bytes>" bearer="<base64-encoded-opaque-blob>"
+   Authentication-Info: libp2p-PeerID sig="<base64-signature-bytes>" bearer="<base64-encoded-opaque-blob>"
    ```
 
    The `sig` param represents a signature over the parameters:


### PR DESCRIPTION
There should not be a comma after the authentication scheme name.