### PR TITLE
docs: adds an expires field to the bearer token response

### DIFF
--- a/http/peer-id-auth.md
+++ b/http/peer-id-auth.md
@@ -177,7 +177,7 @@ protocol operates as follows:
    format:
 
    ```
-   Authentication-Info: libp2p-PeerID sig="<base64-signature-bytes>" bearer="<base64-encoded-opaque-blob>" expires="<ISO-8601-formatted-date-string>"
+   Authentication-Info: libp2p-PeerID sig="<base64-signature-bytes>" bearer="<base64-encoded-opaque-blob>" expires="<RFC-3339-formatted-date-string>"
    ```
 
    Note that the `expires` field is only advisory, the server may expire the
@@ -271,7 +271,7 @@ The client initiated handshake is as follows
    format:
 
    ```
-   Authentication-Info: libp2p-PeerID bearer="<base64-encoded-opaque-blob>" expires="<ISO-8601-formatted-date-string>"
+   Authentication-Info: libp2p-PeerID bearer="<base64-encoded-opaque-blob>" expires="<RFC-3339-formatted-date-string>"
    ```
 
    Note that the `expires` field is only advisory, the server may expire the

--- a/http/peer-id-auth.md
+++ b/http/peer-id-auth.md
@@ -173,8 +173,7 @@ protocol operates as follows:
    ```
 
    The server MAY include an `expires` field which contains the expiry time of
-   the bearer token in [ISO-8601](https://www.iso.org/iso-8601-date-and-time-format.html)
-   format:
+   the bearer token in [RFC3339](https://www.rfc-editor.org/rfc/rfc3339) format:
 
    ```
    Authentication-Info: libp2p-PeerID sig="<base64-signature-bytes>" bearer="<base64-encoded-opaque-blob>" expires="<ISO-8601-formatted-date-string>"
@@ -267,8 +266,7 @@ The client initiated handshake is as follows
    - The token creation date (to allow tokens to expire).
   
    The server MAY include an `expires` field which contains the expiry time of
-   the bearer token in [ISO-8601](https://www.iso.org/iso-8601-date-and-time-format.html)
-   format:
+   the bearer token in [RFC3339](https://www.rfc-editor.org/rfc/rfc3339) format:
 
    ```
    Authentication-Info: libp2p-PeerID bearer="<base64-encoded-opaque-blob>" expires="<ISO-8601-formatted-date-string>"

--- a/http/peer-id-auth.md
+++ b/http/peer-id-auth.md
@@ -173,7 +173,8 @@ protocol operates as follows:
    ```
 
    The server MAY include an `expires` field which contains the expiry time of
-   the bearer token in [RFC3339](https://www.rfc-editor.org/rfc/rfc3339) format:
+   the bearer token in [RFC 3339](https://www.rfc-editor.org/rfc/rfc3339)
+   format:
 
    ```
    Authentication-Info: libp2p-PeerID sig="<base64-signature-bytes>" bearer="<base64-encoded-opaque-blob>" expires="<ISO-8601-formatted-date-string>"
@@ -266,7 +267,8 @@ The client initiated handshake is as follows
    - The token creation date (to allow tokens to expire).
   
    The server MAY include an `expires` field which contains the expiry time of
-   the bearer token in [RFC3339](https://www.rfc-editor.org/rfc/rfc3339) format:
+   the bearer token in [RFC 3339](https://www.rfc-editor.org/rfc/rfc3339)
+   format:
 
    ```
    Authentication-Info: libp2p-PeerID bearer="<base64-encoded-opaque-blob>" expires="<ISO-8601-formatted-date-string>"

--- a/http/peer-id-auth.md
+++ b/http/peer-id-auth.md
@@ -2,7 +2,7 @@
 
 | Lifecycle Stage | Maturity      | Status | Latest Revision |
 | --------------- | ------------- | ------ | --------------- |
-| 1A              | Working Draft | Active | r0, 2023-01-23  |
+| 1A              | Working Draft | Active | r1, 2025-05-28  |
 
 Authors: [@MarcoPolo]
 
@@ -265,7 +265,7 @@ The client initiated handshake is as follows
    - The client's Peer ID.
    - The `hostname` parameter.
    - The token creation date (to allow tokens to expire).
-  
+
    The server MAY include an `expires` field which contains the expiry time of
    the bearer token in [RFC 3339](https://www.rfc-editor.org/rfc/rfc3339)
    format:

--- a/http/peer-id-auth.md
+++ b/http/peer-id-auth.md
@@ -197,7 +197,7 @@ protocol operates as follows:
    - The `hostname` parameter.
    - The token creation date (to allow tokens to expire).
 
-6. The client MUST verify the signature. After verification the client has
+5. The client MUST verify the signature. After verification the client has
    authenticated the server's Peer ID. The client SHOULD send the `bearer`
    token for Peer ID authenticated requests.
 
@@ -277,7 +277,7 @@ The client initiated handshake is as follows
    Note that the `expires` field is only advisory, the server may expire the
    token at any time.
 
-6. The client SHOULD send the `bearer` token for future Peer ID authenticated
+5. The client SHOULD send the `bearer` token for future Peer ID authenticated
    requests.
 
 ## libp2p bearer token

--- a/http/peer-id-auth.md
+++ b/http/peer-id-auth.md
@@ -172,6 +172,17 @@ protocol operates as follows:
    Authentication-Info: libp2p-PeerID sig="<base64-signature-bytes>" bearer="<base64-encoded-opaque-blob>"
    ```
 
+   The server MAY include an `expires` field which contains the expiry time of
+   the bearer token in [ISO-8601](https://www.iso.org/iso-8601-date-and-time-format.html)
+   format:
+
+   ```
+   Authentication-Info: libp2p-PeerID sig="<base64-signature-bytes>" bearer="<base64-encoded-opaque-blob>" expires="<ISO-8601-formatted-date-string>"
+   ```
+
+   Note that the `expires` field is only advisory, the server may expire the
+   token at any time.
+
    The `sig` param represents a signature over the parameters:
 
    - `challenge-server`
@@ -186,7 +197,7 @@ protocol operates as follows:
    - The `hostname` parameter.
    - The token creation date (to allow tokens to expire).
 
-5. The client MUST verify the signature. After verification the client has
+6. The client MUST verify the signature. After verification the client has
    authenticated the server's Peer ID. The client SHOULD send the `bearer`
    token for Peer ID authenticated requests.
 
@@ -254,8 +265,19 @@ The client initiated handshake is as follows
    - The client's Peer ID.
    - The `hostname` parameter.
    - The token creation date (to allow tokens to expire).
+  
+   The server MAY include an `expires` field which contains the expiry time of
+   the bearer token in [ISO-8601](https://www.iso.org/iso-8601-date-and-time-format.html)
+   format:
 
-5. The client SHOULD send the `bearer` token for future Peer ID authenticated
+   ```
+   Authentication-Info: libp2p-PeerID bearer="<base64-encoded-opaque-blob>" expires="<ISO-8601-formatted-date-string>"
+   ```
+
+   Note that the `expires` field is only advisory, the server may expire the
+   token at any time.
+
+6. The client SHOULD send the `bearer` token for future Peer ID authenticated
    requests.
 
 ## libp2p bearer token


### PR DESCRIPTION
Where a bearer token is returned to the client for future use, optionally include an `expires` field which indicates the latest time that it will be treated as valid.

The server is free to expire tokens at any time so this field is purely advisory.

Fixes #674