### PR TITLE
fix: update AutoNAT link to actual spec in hole-punching.md

### DIFF
--- a/connections/hole-punching.md
+++ b/connections/hole-punching.md
@@ -158,7 +158,7 @@ connections across the various permutations of the two dimensions.
 
 [TURN]: https://en.wikipedia.org/wiki/Traversal_Using_Relays_around_NAT
 [STUN]: https://en.wikipedia.org/wiki/STUN
-[AutoNAT]: https://github.com/libp2p/specs/issues/180
+[AutoNAT]: ../autonat/README.md
 [Identify]: ../identify/README.md
 [SDP]: https://en.wikipedia.org/wiki/Session_Description_Protocol
 [circuit-relay-v2]: https://github.com/libp2p/specs/blob/master/relay/circuit-v2.md


### PR DESCRIPTION
The [AutoNAT] reference link in connections/hole-punching.md pointed to issue #180 (a tracking issue about creating the spec). The actual AutoNAT specification now exists at autonat/README.md.

Updated to use a relative path consistent with other reference links in the file (e.g., [Identify]: ../identify/README.md).

Fixes #697