### PR TITLE
gossipsub: downscore peers on protocol violations

### DIFF
--- a/pubsub/gossipsub/gossipsub-v1.2.md
+++ b/pubsub/gossipsub/gossipsub-v1.2.md
@@ -2,7 +2,7 @@
 
 | Lifecycle Stage | Maturity                  | Status | Latest Revision |
 |-----------------|---------------------------|--------|-----------------|
-| 1A              | Working Draft             | Active | r1, 2023-07-14  |
+| 1A              | Working Draft             | Active | r2, 2026-08-30  |
 
 Authors: [@Nashatyrev], [@Menduist]
 

--- a/pubsub/gossipsub/gossipsub-v1.2.md
+++ b/pubsub/gossipsub/gossipsub-v1.2.md
@@ -76,6 +76,10 @@ on per message basis when the size is exceeded or just use `IDONTWANT` for all m
 
 To prevent DoS the number of `IDONTWANT` control messages is limited to `max_idontwant_messages` per heartbeat  
 
+The receiver SHOULD ignore the `IDONTWANT` messages beyond `max_idontwant_messages` within a heartbeat, and SHOULD
+downscore the peer that sent them, but only when `max_idontwant_messages` is agreed across the network. An
+implementation that disagrees with its peers on this value downscores honest peers.
+
 ### Cancelling `IWANT`
 
 If a node requested a message via `IWANT` and then occasionally receives the message from other peer it MAY 

--- a/pubsub/gossipsub/gossipsub-v1.3.md
+++ b/pubsub/gossipsub/gossipsub-v1.3.md
@@ -43,6 +43,8 @@ included in the first message on the stream. An Extensions control message MUST
 NOT be sent more than once. If a peer supports no extensions, it may omit
 sending the Extensions control message.
 
+The receiver SHOULD downscore a peer that violates either rule.
+
 Extensions are not negotiated; they describe characteristics of the sending peer
 that can be used by the receiving peer. However, a negotiation can be implied:
 each peer uses the Extensions control message to advertise a set of supported
@@ -56,6 +58,20 @@ to combine with other extensions that modify or replace the same functionality
 unless the behavior of the combination is explicitly defined. Such extensions
 SHOULD define their interaction with previously defined extensions modifying the
 same protocol components.
+
+## Peer Scoring on Protocol Violations
+
+If a peer sends a message that violates a MUST or MUST NOT condition of this
+document, or of an extension the peer advertises, the receiver SHOULD downscore
+the peer through the `P₇` behavioural penalty defined in [gossipsub
+v1.1][gossipsub-v1.1-scoring]. This covers only the conditions that the receiver
+can check from the messages it receives. An extension MAY define a stronger
+remedy, such as resetting the connection.
+
+A receiver MUST NOT downscore a peer for a message that the peer could have sent
+before it processed the receiver's latest subscription change.
+
+[gossipsub-v1.1-scoring]: https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.1.md#peer-scoring
 
 ## Protocol ID
 

--- a/pubsub/gossipsub/partial-messages.md
+++ b/pubsub/gossipsub/partial-messages.md
@@ -133,7 +133,10 @@ to send the peer a full message or a partial message.
 If a peer supports partial messages on a topic but did not request them, a node
 MUST omit the `partialMessage` field of the `PartialMessagesExtension` message
 when sending a message to this peer. In other words, it MUST NOT send this peer
-encoded partialMessage data since it did not request it.
+encoded partialMessage data since it did not request it. A node that receives a
+`partialMessage` field for a topic it did not request partial messages on SHOULD
+downscore the sending peer, unless the peer could have sent the message before it
+processed the node's latest `SubOpts` for that topic.
 
 If a node does not support the partial message extension, it MUST ignore the
 `requestPartial` and `supportsPartial` fields. This is the default behavior of
@@ -165,6 +168,13 @@ message for a given topic.
 | ------------------------ | ------------------------------------------------------------------------ |
 | \*                       | The receiver expects full messages                                       |
 
+
+## Peer Scoring on Protocol Violations
+
+A receiver scores violations of this extension as described in [Peer Scoring on
+Protocol Violations][gossipsub-v1.3-violations].
+
+[gossipsub-v1.3-violations]: https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.3.md#peer-scoring-on-protocol-violations
 
 ## Partial Message Gossip
 


### PR DESCRIPTION
Follow-up to https://github.com/libp2p/specs/pull/729#discussion_r3775156137, where @MarcoPolo asked for a separate PR.

The Topic Streams Extension says a receiver SHOULD downscore a peer for some spec violations. Other gossipsub documents state MUST and MUST NOT conditions without saying what a receiver does when a peer breaks them. This PR states the consequence once, in the extensions framework document, and applies it where an extension needs a specific rule.

`gossipsub-v1.3.md` gets a new "Peer Scoring on Protocol Violations" section:

- A peer that sends a message which violates a MUST or MUST NOT condition SHOULD be downscored through the `P₇` behavioural penalty from gossipsub v1.1.
- The rule covers only the conditions that a receiver can check from the messages it receives. It does not cover the process rules of this document, such as the requirement to update `extensions.proto`.
- An extension MAY define a stronger remedy, such as a connection reset. This keeps the rule compatible with #729, which resets the connection and sends an error code.
- A receiver MUST NOT downscore a peer for a message that the peer could have sent before it processed the receiver's latest subscription change. #729 carves out the same race for topic streams. Without it, a node that unsubscribes penalises every honest peer with a message already on the wire.

The Extensions control message rules now state their consequence: a receiver SHOULD downscore a peer that sends the message after the first message on the stream, or sends more than one.

`partial-messages.md` points at the v1.3 section, and states the one rule that needs the extension's own terms: a node that receives a `partialMessage` field for a topic it did not request partial messages on SHOULD downscore the sending peer, unless the peer could have sent it before processing the node's latest `SubOpts` for that topic.

Two documents are left alone on purpose. `gossipsub-v1.1.md` already owns the scoring machinery, and adding a blanket penalty rule to it is a semantic change rather than an editorial one. `extensions/experimental/test-extension.md` exists to test interop, so a penalty there is noise.
