### PR TITLE
Gossipsub: make partial message part forwarding normative

### DIFF
--- a/pubsub/gossipsub/partial-messages.md
+++ b/pubsub/gossipsub/partial-messages.md
@@ -203,7 +203,7 @@ Application MUST be able to send partial messages to these peers.
 
 ## Forwarding Message Parts Without Knowing Full Message
 
-A node that requested partial messages receives parts before it has the full
+A node that requested partial messages may receive parts before it has the full
 message. When a received part is individually verifiable, the application
 SHOULD validate it and SHOULD then forward it to mesh peers that requested
 partial messages for the topic, without waiting for the full message. This

--- a/pubsub/gossipsub/partial-messages.md
+++ b/pubsub/gossipsub/partial-messages.md
@@ -225,7 +225,7 @@ To avoid resending data, an implementation SHOULD track, for each `(peer, Group 
 - **Last sent metadata**: the `partsMetadata` this implementation last sent to
   the peer.
 
-When the group is published again, the implementation SHOULD only send  parts
+When the group is published again, the implementation SHOULD only send parts
 the peer does not yet have, and attach its current `partsMetadata` only if
 it has changed since it was last sent. If neither condition holds, nothing is
 sent to that peer. This state is per-message and SHOULD be dropped after a

--- a/pubsub/gossipsub/partial-messages.md
+++ b/pubsub/gossipsub/partial-messages.md
@@ -68,8 +68,8 @@ Partial messages enable further optimizations:
 
 - If cells can be validated individually, as in the case of DAS, partial
   messages can also be forwarded before the node has the full message (see
-  [Forwarding Message Parts](#forwarding-message-parts)), allowing us to
-  reduce the store-and-forward delay [2].
+  [Forwarding Message Parts Without Knowing Full Message](#forwarding-message-parts-without-knowing-full-message)),
+  helping to reduce the store-and-forward delay [2].
 - Finally, in the FullDAS construct, where both row and column topics are
   defined, partial messages allow cross-forwarding cells between these topics
   [2].
@@ -201,12 +201,7 @@ messages, without eager data, require an exchange of bitmaps before parts are
 transferred. In order for fanout and gossip messages to be useful, the
 Application MUST be able to send partial messages to these peers.
 
-## Forwarding Message Parts
-
-Some applications can validate a message part on its own, without the full
-message. Such a part is individually verifiable. For example, a node can
-validate a DAS cell against its KZG commitment without the other cells in the
-column.
+## Forwarding Message Parts Without Knowing Full Message
 
 A node that requested partial messages receives parts before it has the full
 message. When a received part is individually verifiable, the application
@@ -214,17 +209,26 @@ SHOULD validate it and SHOULD then forward it to mesh peers that requested
 partial messages for the topic, without waiting for the full message. This
 removes the store-and-forward delay of full message relay [2].
 
-An application MUST NOT forward a part that failed validation.
+An application MUST NOT forward a part that failed validation or that cannot be
+individually validated.
 
 To support this, implementations MUST accept a partial message publish for a
 group before the application has the full message, and MUST accept repeated
 publishes for the same group as the application obtains more parts.
-Implementations SHOULD track per-peer state so that repeated publishes only
+Implementations SHOULD track peer state so that repeated publishes only
 send parts and metadata a peer does not already have.
 
-Parts that are not individually verifiable MUST NOT be forwarded before the
-full message validates. Applications with such parts fall back to
-store-and-forward relay of the reconstructed full message.
+To track this state, an implementation keeps two records for each peer and
+Group ID: the parts it believes the peer has, and the `partsMetadata` it last
+sent to the peer. The first record starts from the last `partsMetadata`
+received from the peer and is updated with every part the implementation sends
+to the peer. The second record is the implementation's own `partsMetadata` as
+of the last send. On a repeated publish for the group, the implementation
+sends only the parts absent from the first record, and includes its
+`partsMetadata` only if it differs from the second record. If neither record
+changes, it sends nothing to that peer. Both records are per-message state and
+SHOULD be dropped after a bounded number of heartbeats (see
+[DoS Resiliency](#dos-resiliency)).
 
 ## Implementation Recommendations
 

--- a/pubsub/gossipsub/partial-messages.md
+++ b/pubsub/gossipsub/partial-messages.md
@@ -218,17 +218,18 @@ publishes for the same group as the application obtains more parts.
 Implementations SHOULD track peer state so that repeated publishes only
 send parts and metadata a peer does not already have.
 
-To track this state, an implementation keeps two records for each peer and
-Group ID: the parts it believes the peer has, and the `partsMetadata` it last
-sent to the peer. The first record starts from the last `partsMetadata`
-received from the peer and is updated with every part the implementation sends
-to the peer. The second record is the implementation's own `partsMetadata` as
-of the last send. On a repeated publish for the group, the implementation
-sends only the parts absent from the first record, and includes its
-`partsMetadata` only if it differs from the second record. If neither record
-changes, it sends nothing to that peer. Both records are per-message state and
-SHOULD be dropped after a bounded number of heartbeats (see
-[DoS Resiliency](#dos-resiliency)).
+To avoid resending data, an implementation SHOULD track, for each `(peer, Group ID)` pair:
+
+- **Known parts**: which parts the peer already has. This starts from the
+  peer's last `partsMetadata` and grows with each part sent to the peer.
+- **Last sent metadata**: the `partsMetadata` this implementation last sent to
+  the peer.
+
+When the group is published again, the implementation SHOULD only send  parts
+the peer does not yet have, and attach its current `partsMetadata` only if
+it has changed since it was last sent. If neither condition holds, nothing is
+sent to that peer. This state is per-message and SHOULD be dropped after a
+bounded number of heartbeats (see [DoS Resiliency](#dos-resiliency)).
 
 ## Implementation Recommendations
 

--- a/pubsub/gossipsub/partial-messages.md
+++ b/pubsub/gossipsub/partial-messages.md
@@ -2,7 +2,7 @@
 
 | Lifecycle Stage | Maturity      | Status | Latest Revision |
 | --------------- | ------------- | ------ | --------------- |
-| 1A              | Working Draft | Active | r0, 2025-06-23  |
+| 1A              | Working Draft | Active | r1, 2026-08-31  |
 
 Authors: [@marcopolo], [@sukunrt], [@jxs], [@cskiraly]
 
@@ -64,11 +64,12 @@ node has all but one cell, this would result in a transfer of 2KiB rather than
 64KiB per column. and since nodes custody at least 8 columns, the total savings
 per slot is around 500KiB.
 
-Later, partial messages could enable further optimizations:
+Partial messages enable further optimizations:
 
 - If cells can be validated individually, as in the case of DAS, partial
-  messages could also be forwarded, allowing us to reduce the store-and-forward
-  delay [2].
+  messages can also be forwarded before the node has the full message (see
+  [Forwarding Message Parts](#forwarding-message-parts)), allowing us to
+  reduce the store-and-forward delay [2].
 - Finally, in the FullDAS construct, where both row and column topics are
   defined, partial messages allow cross-forwarding cells between these topics
   [2].
@@ -199,6 +200,31 @@ Fanout and Gossip messages by definition come from non-mesh peers. Partial
 messages, without eager data, require an exchange of bitmaps before parts are
 transferred. In order for fanout and gossip messages to be useful, the
 Application MUST be able to send partial messages to these peers.
+
+## Forwarding Message Parts
+
+Some applications can validate a message part on its own, without the full
+message. Such a part is individually verifiable. For example, a node can
+validate a DAS cell against its KZG commitment without the other cells in the
+column.
+
+A node that requested partial messages receives parts before it has the full
+message. When a received part is individually verifiable, the application
+SHOULD validate it and SHOULD then forward it to mesh peers that requested
+partial messages for the topic, without waiting for the full message. This
+removes the store-and-forward delay of full message relay [2].
+
+An application MUST NOT forward a part that failed validation.
+
+To support this, implementations MUST accept a partial message publish for a
+group before the application has the full message, and MUST accept repeated
+publishes for the same group as the application obtains more parts.
+Implementations SHOULD track per-peer state so that repeated publishes only
+send parts and metadata a peer does not already have.
+
+Parts that are not individually verifiable MUST NOT be forwarded before the
+full message validates. Applications with such parts fall back to
+store-and-forward relay of the reconstructed full message.
 
 ## Implementation Recommendations
 


### PR DESCRIPTION
## Summary

The partial-messages spec mentions forwarding parts before full receipt only as a motivation-level possibility ("partial messages could also be forwarded").  This PR promotes that behavior to normative requirements and bumps the revision to r1.

The new **Forwarding Message Parts** section specifies:

- A part that the application can validate on its own is individually verifiable.
- Applications SHOULD validate individually verifiable parts on receipt and SHOULD forward validated parts to mesh peers that requested partial messages, without waiting for the full message.
- Applications MUST NOT forward a part that failed validation.
- Implementations MUST accept a partial publish for a group before the full message is known, MUST accept repeated publishes for the same group as more parts arrive, and SHOULD deduplicate per peer so repeated publishes only send what a peer lacks.
- Parts that are not individually verifiable MUST NOT be forwarded before the full message validates.

The Motivation bullet now points at the new section instead of the "could" phrasing.

## Why normative, and why now

This codifies behavior that is already deployed rather than proposing new behavior:

- The rust-libp2p implementation of this extension (libp2p/rust-libp2p#6275) places no completeness requirement on `publish_partial`: it caches the application's partial, supports incremental re-publish of a growing group, and skips sends whose metadata adds nothing.
- Lighthouse's cell dissemination (sigp/lighthouse#8314, merged 2026-04-23) uses exactly this path in production code: every merge that adds KZG-verified cells to a still-incomplete column immediately republishes the incomplete column to the network (`PartialDataColumnAssembler::merge_partials` returns `updated_partials`, which `gossip_methods` publishes via `publish_partial`).

Making the forwarding rule normative gives other implementations and applications a clear interop target for the store-and-forward latency win that motivated the extension, and pins down the safety condition (individual verifiability plus validation before forwarding) that the deployed code already honors.

## Relationship to the v1.4 work

Complementary to #654 / #720: those define fragmentation and pipelined relay for opaque payloads at the protocol layer, while this change covers applications with application-defined verifiable parts on the shipped v1.3 partial-messages extension.
